### PR TITLE
[ONEM-20558] Increase timeupdate timer to pass YT progressive test #29

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3903,7 +3903,7 @@ void HTMLMediaElement::scanTimerFired()
 
 // The spec says to fire periodic timeupdate events (those sent while playing) every
 // "15 to 250ms", we choose the slowest frequency
-static const Seconds maxTimeupdateEventFrequency { 200_ms };
+static const Seconds maxTimeupdateEventFrequency { 230_ms };
 
 void HTMLMediaElement::startPlaybackProgressTimer()
 {


### PR DESCRIPTION
Increase timeupdate timer which is still in the specification range [15ms - 250ms] to properly detect decoder position for low playback rates. This is done to pass Youtube 2021 progressive test number 29 "maxGranularityPlaybackRate 0.25".