### PR TITLE
[ONEM-20304] cache the values of the query 'get_frame_drop_stats'

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -145,6 +145,12 @@ public:
 
     String errorMessage() const override { return m_errorMessage; }
 
+#if ENABLE(MEDIA_SOURCE)
+    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() override;
+#endif
+    unsigned decodedFrameCount() const override;
+    unsigned droppedFrameCount() const override;
+
 private:
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
@@ -197,6 +203,8 @@ private:
 #endif
 
     long long determineTotalBytes() const;
+
+    void updateFrameStats() const;
 
 protected:
     bool m_buffering;
@@ -306,6 +314,9 @@ private:
     virtual bool isMediaSource() const { return false; }
 
     String m_errorMessage;
+
+    mutable guint m_decoded_frames = 0;
+    mutable guint m_dropped_frames = 0;
 };
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -817,59 +817,6 @@ bool MediaPlayerPrivateGStreamerMSE::isTimeBuffered(const MediaTime &time) const
     return result;
 }
 
-std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateGStreamerMSE::videoPlaybackQualityMetrics()
-{
-#if PLATFORM(BROADCOM)
-#if USE(WESTEROS_SINK)
-    if (!m_videoSink)
-        return std::nullopt;
-    GRefPtr<GstPad> videoSinkPad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
-    if (!videoSinkPad)
-        return std::nullopt;
-    GstStructure *structure =
-        gst_structure_new("get_video_playback_quality",
-                          "total", G_TYPE_UINT, 0,
-                          "dropped", G_TYPE_UINT, 0,
-                          "corrupted", G_TYPE_UINT, 0,
-                          nullptr);
-    GstQuery *query = gst_query_new_custom(GST_QUERY_CUSTOM, structure);
-    if (!gst_pad_query(videoSinkPad.get(), query)) {
-        gst_query_unref(query);
-        return std::nullopt;
-    }
-    guint total = 0;
-    guint dropped = 0;
-    guint corrupted = 0;
-    structure = (GstStructure *)gst_query_get_structure(query);
-    if (!gst_structure_get_uint(structure, "total", &total))
-        total = 0;
-    if (!gst_structure_get_uint(structure, "dropped", &dropped))
-        dropped = 0;
-    if (!gst_structure_get_uint(structure, "corrupted", &corrupted))
-        corrupted = 0;
-    gst_query_unref(query);
-    return VideoPlaybackQualityMetrics {total, dropped, corrupted, 0};
-#else
-    GRefPtr<GstQuery> query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("get_frame_drop_stats")));
-    if (gst_element_query(m_pipeline.get(), query.get())) {
-        const GstStructure *ret = gst_query_get_structure(query.get());
-        guint decoded_frames;
-        if (gst_structure_get_uint(ret, "decoded_frames", &decoded_frames)){
-            m_cached_decoded_frames = decoded_frames;
-        }
-
-        guint dropped_frames;
-        if (gst_structure_get_uint(ret, "dropped_frames", &dropped_frames)) {
-            m_cached_dropped_frames = dropped_frames;
-        }
-    }
-
-    return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};
-#endif // USE(WESTEROS_SINK)
-#endif // PLATFORM(BROADCOM)
-    return VideoPlaybackQualityMetrics { decodedFrameCount(), droppedFrameCount(), 0, 0.0 };
-}
-
 bool MediaPlayerPrivateGStreamerMSE::playbackPipelineHasFutureData() const
 {
     if (!m_playbackPipeline || m_isEndReached || m_errorOccured)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -852,24 +852,24 @@ std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateGStreamerMSE::video
 #else
     GRefPtr<GstQuery> query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("get_frame_drop_stats")));
     if (!gst_element_query(m_pipeline.get(), query.get())) {
-        return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};;
+        return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};
     }
 
     const GstStructure *ret = gst_query_get_structure(query.get());
     guint decoded_frames;
     if (!gst_structure_get_uint(ret, "decoded_frames", &decoded_frames)){
-        return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};;
+        return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};
     }
 
     guint dropped_frames;
     if (!gst_structure_get_uint(ret, "dropped_frames", &dropped_frames)) {
-        return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};;
+        return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};
     }
 
     m_cached_decoded_frames = decoded_frames;
     m_cached_dropped_frames = dropped_frames;
 
-    return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};;
+    return VideoPlaybackQualityMetrics {m_cached_decoded_frames, m_cached_dropped_frames, 0, 0};
 #endif // USE(WESTEROS_SINK)
 #endif // PLATFORM(BROADCOM)
     return VideoPlaybackQualityMetrics { decodedFrameCount(), droppedFrameCount(), 0, 0.0 };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -136,6 +136,8 @@ private:
     bool m_didLogRebufferingOnce { false };
     URL m_url;
     bool m_didFirstSeek = false;
+    guint m_cached_decoded_frames = 0;
+    guint m_cached_dropped_frames = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -115,7 +115,6 @@ private:
     void updatePlaybackRate() override;
     void asyncStateChangeDone() override;
 
-    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
     bool isTimeBuffered(const MediaTime&) const;
     bool playbackPipelineHasFutureData() const;
 


### PR DESCRIPTION
We need to cache the values of the query 'get_frame_drop_stats' to solve
the problem for the case when the playback ends and we need the information
from that query.

+ replace rendered_frames with decoded_frames