### PR TITLE
[ONEM-22296] - conditionally convert playready KID

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -49,6 +49,8 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
+#include <rdk/libodherr/odherr.h>
+
 #if HAVE(SIGNAL_H)
 #include <signal.h>
 #endif
@@ -315,11 +317,26 @@ void WTFReportFatalError(const char* file, int line, const char* function, const
     printCallSite(file, line, function);
 }
 
+static void report_odh_error(const char* format, va_list args)
+{
+    int length = vsnprintf(NULL, 0, format, args);
+    if (length < 0) return;
+
+    char *msg = (char*)malloc(length + 1);
+    if (!msg) return;
+
+    vsnprintf(msg, length + 1, format, args);
+    ODH_ERROR_REPORT_SRC_ERROR_V3("0", NULL, msg, NULL,   NULL);
+    free(msg);
+}
+
 void WTFReportError(const char* file, int line, const char* function, const char* format, ...)
 {
     va_list args;
     va_start(args, format);
     vprintf_stderr_with_prefix("ERROR: ", format, args);
+    // report error to ODH
+    report_odh_error(format, args);
     va_end(args);
     printf_stderr_common("\n");
     printCallSite(file, line, function);

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -484,6 +484,7 @@ list(APPEND WTF_LIBRARIES
     ${ICU_DATA_LIBRARIES}
     ${ICU_I18N_LIBRARIES}
     ${ICU_LIBRARIES}
+    odherr
 )
 
 if (WIN32)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -49,7 +49,9 @@
 
 namespace {
 
-void ToggleKeyIdFormat(Ref<WebCore::SharedBuffer>& playreadyKID)
+bool gWorkaroundForShaka = getenv("CONVERT_PLAYREADY_KEY_ID_FOR_SHAKA") != nullptr && *getenv("CONVERT_PLAYREADY_KEY_ID_FOR_SHAKA") == '1';
+
+void ConvertKIDEndianness(Ref<WebCore::SharedBuffer>& playreadyKID)
 {
     const char* playreadyKeyId = playreadyKID->data();
 
@@ -697,10 +699,10 @@ void MediaKeySession::updateKeyStatuses(CDMInstanceClient::KeyStatusVector&& inp
 
     m_statuses.clear();
     m_statuses.reserveCapacity(inputStatuses.size());
-    const char* workaroundConvertPlayreadyKeyID = getenv("WORKAROUND_CONVERT_PLAYREADY_KEY_ID");
     for (auto& status : inputStatuses) {
-        if (workaroundConvertPlayreadyKeyID) {
-            ToggleKeyIdFormat(status.first);
+        if (gWorkaroundForShaka) {
+            LOG(EME, "EME - workaround for Shaka, convert KID endianness");
+            ConvertKIDEndianness(status.first);
         }
 
         m_statuses.uncheckedAppend({ WTFMove(status.first), toMediaKeyStatus(status.second) });


### PR DESCRIPTION
Due to the fact that OCDM convert playready key ID to cenc format
and unfortunately ShakaPlayer in version < 3.0.5 does it also, we need
to reconvert keyID before we send it to ShakaPlayer.