### PR TITLE
[ONEM-21143] Add |ac-3| to the list of MSE supported codecs

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -943,7 +943,7 @@ const static HashSet<AtomicString>& codecSet()
             { VideoDecoder, "video/x-vp9", { "vp9", "x-vp9" } },
             { AudioDecoder, "audio/x-vorbis", { "vorbis", "x-vorbis" } },
             { AudioDecoder, "audio/x-opus", { "opus", "x-opus" } },
-            { AudioDecoder, "audio/x-ac3", {"x-ac3", "ac3" } },
+            { AudioDecoder, "audio/x-ac3", {"x-ac3", "ac3", "ac-3" } },
             { AudioDecoder, "audio/x-eac3", {"x-eac3", "ec3", "ec-3", "eac3"} }
         } };
 


### PR DESCRIPTION
|MediaSource.isTypeSupported| accepts only following AC-3
mimetypes: |x-ac3|, |ac3|. Some pages (like html5test.com) use |ac-3|
name, which had been needlessly rejected.