### PR TITLE
ONEM-22761 Fix building using python3

### DIFF
--- a/Source/JavaScriptCore/generate-bytecode-files
+++ b/Source/JavaScriptCore/generate-bytecode-files
@@ -215,7 +215,7 @@ if __name__ == "__main__":
         initBytecodesFile = openOrExit(initASMFileName, "w")
 
     try:
-        bytecodeSections = json.load(bytecodeFile, encoding = "utf-8")
+        bytecodeSections = json.loads(bytecodeFile.read().decode('UTF-8'))
     except:
         print("Unexpected error parsing {0}: {1}".format(bytecodeJSONFile, sys.exc_info()))
 


### PR DESCRIPTION
Fixes:

Unexpected error parsing \
wpe-webkit/1_2.22.1+git-r0/git/Source/JavaScriptCore/bytecode/BytecodeList.json: (<class
 'TypeError'>, TypeError("the JSON object must be str, not 'bytes'",), \
<traceback object at 0x7fa7410fc0c8>)
Traceback (most recent call last):
  File "wpe-webkit/1_2.22.1+git-r0/git/Source/JavaScriptCore/generate-bytecode-files", line 239, in <module>
    for section in bytecodeSections:
NameError: name 'bytecodeSections' is not defined

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>