### PR TITLE
[ONEM-22864] Send ODH error when RDK logger is enabled

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -317,7 +317,27 @@ void WTFReportFatalError(const char* file, int line, const char* function, const
     printCallSite(file, line, function);
 }
 
-static void report_odh_error(const char* format, va_list args)
+void WTFReportError(const char* file, int line, const char* function, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vprintf_stderr_with_prefix("ERROR: ", format, args);
+    // report error to ODH
+    WTFReportOdhErrorV(format, args);
+    va_end(args);
+    printf_stderr_common("\n");
+    printCallSite(file, line, function);
+}
+
+void WTFReportOdhError(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    WTFReportOdhErrorV(format, args);
+    va_end(args);
+}
+
+void WTFReportOdhErrorV(const char* format, va_list args)
 {
     int length = vsnprintf(NULL, 0, format, args);
     if (length < 0) return;
@@ -328,18 +348,6 @@ static void report_odh_error(const char* format, va_list args)
     vsnprintf(msg, length + 1, format, args);
     ODH_ERROR_REPORT_SRC_ERROR_V3("0", NULL, msg, NULL,   NULL);
     free(msg);
-}
-
-void WTFReportError(const char* file, int line, const char* function, const char* format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    vprintf_stderr_with_prefix("ERROR: ", format, args);
-    // report error to ODH
-    report_odh_error(format, args);
-    va_end(args);
-    printf_stderr_common("\n");
-    printCallSite(file, line, function);
 }
 
 class WTFLoggingAccumulator {

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -224,6 +224,8 @@ WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 WTF_EXPORT_PRIVATE void WTFGetBacktrace(void** stack, int* size);
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 WTF_EXPORT_PRIVATE void WTFPrintBacktrace(void** stack, int size);
+WTF_EXPORT_PRIVATE void WTFReportOdhError(const char* format, ...);
+WTF_EXPORT_PRIVATE void WTFReportOdhErrorV(const char* format, va_list args);
 #if !RELEASE_LOG_DISABLED
 WTF_EXPORT_PRIVATE void WTFReleaseLogStackTrace(WTFLogChannel*);
 #endif
@@ -484,6 +486,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 #define LOG_ERROR(...) do { \
     RDK_LOG_VERBOSE(RDK_LOG_ERROR, RDK_LOG_DEFAULT_CHANNEL); \
     RDK_LOG(RDK_LOG_ERROR, RDK_LOG_DEFAULT_CHANNEL, __VA_ARGS__); \
+    WTFReportOdhError(__VA_ARGS__); \
 } while (0)
 #else
 #define LOG_ERROR(...) WTFReportError(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, __VA_ARGS__)


### PR DESCRIPTION
When RDK logger is enabled for WPE WebKit and error log is printed, send
ODH error report as well.