### PR TITLE
[ONEM-22416] Runtime GNU TLS cipher priority change

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -365,6 +365,18 @@ void NetworkProcess::createNetworkConnectionToWebProcess()
         m_webProcessConnections.last()->setOnLineState(NetworkStateNotifier::singleton().onLine());
 }
 
+void NetworkProcess::setGnuTlsCipherPriority(String gnuTlsCipherPriority)
+{
+    const char *requestedPrio = gnuTlsCipherPriority.utf8().data();
+    char *currentPrio = getenv("G_TLS_GNUTLS_PRIORITY");
+
+    // In case env variable is not set, getenv() will return a NULL pointer which crashes strcmp()
+    if (currentPrio && strcmp(currentPrio, requestedPrio)) {
+        LOG(Network, "Setting GNU TLS cipher priority to: %s\n", requestedPrio);
+        setenv("G_TLS_GNUTLS_PRIORITY", requestedPrio, 1);
+    }
+}
+
 void NetworkProcess::clearCachedCredentials()
 {
     NetworkStorageSession::defaultStorageSession().credentialStorage().clearCredentials();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -243,6 +243,8 @@ private:
     void setNetworkProxySettings(const WebCore::SoupNetworkProxySettings&);
 #endif
 
+    void setGnuTlsCipherPriority(String gnuTlsCipherPriority);
+
 #if PLATFORM(MAC)
     static void setSharedHTTPCookieStorage(const Vector<uint8_t>& identifier);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -100,4 +100,5 @@ messages -> NetworkProcess LegacyReceiver {
     RegisterURLSchemeAsCanDisplayOnlyIfCanRequest(String scheme)
 
     SetCacheStorageParameters(PAL::SessionID sessionID, uint64_t quota, String cacheStorageDirectory, WebKit::SandboxExtension::Handle handle);
+    SetGnuTlsCipherPriority(String gnuTlsCipherPriority)
 }

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -631,6 +631,11 @@ void WKContextTerminateStorageProcess(WKContextRef context)
     toImpl(context)->terminateStorageProcessForTesting();
 }
 
+void WKContextSetGnuTlsCipherPriority(WKContextRef context, WKStringRef gnuTlsCipherPriority)
+{
+    toImpl(context)->setGnuTlsCipherPriority(toWTFString(gnuTlsCipherPriority));
+}
+
 ProcessID WKContextGetNetworkProcessIdentifier(WKContextRef contextRef)
 {
     return toImpl(contextRef)->networkProcessIdentifier();

--- a/Source/WebKit/UIProcess/API/C/WKContext.h
+++ b/Source/WebKit/UIProcess/API/C/WKContext.h
@@ -172,6 +172,7 @@ WK_EXPORT void WKContextSetAutomationClient(WKContextRef contextRef, const WKCon
 WK_EXPORT void WKContextSetAutomationSession(WKContextRef contextRef, WKWebAutomationSessionRef sessionRef);
 
 WK_EXPORT void WKContextReleaseMemory(WKContextRef contextRef);
+WK_EXPORT void WKContextSetGnuTlsCipherPriority(WKContextRef context, WKStringRef gnuTlsCipherPriority);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -227,6 +227,13 @@ void NetworkProcessProxy::clearCallbackStates()
         m_storageAccessResponseCallbackMap.take(m_storageAccessResponseCallbackMap.begin()->key)(false);
 }
 
+void NetworkProcessProxy::setGnuTlsCipherPriority(const String& gnuTlsCipherPriority)
+{
+    ASSERT(canSendMessage());
+    ASSERT(!gnuTlsCipherPriority.isEmpty());
+    send(Messages::NetworkProcess::SetGnuTlsCipherPriority(gnuTlsCipherPriority), 0);
+}
+
 void NetworkProcessProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (dispatchMessage(connection, decoder))

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -107,6 +107,8 @@ public:
     void addSession(Ref<WebsiteDataStore>&&);
     void removeSession(PAL::SessionID);
 
+    void setGnuTlsCipherPriority(const String& gnuTlsCipherPriority);
+
 private:
     NetworkProcessProxy(WebProcessPool&);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1679,6 +1679,14 @@ void WebProcessPool::terminateServiceWorkerProcesses()
 #endif
 }
 
+void WebProcessPool::setGnuTlsCipherPriority(const String& gnuTlsCipherPriority)
+{
+    if (!m_networkProcess)
+        return;
+
+    m_networkProcess->setGnuTlsCipherPriority(gnuTlsCipherPriority);
+}
+
 void WebProcessPool::syncNetworkProcessCookies()
 {
     ensureNetworkProcess().syncAllCookies();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -290,6 +290,8 @@ public:
     void terminateServiceWorkerProcesses();
     void disableServiceWorkerProcessTerminationDelay();
 
+    void setGnuTlsCipherPriority(const String& gnuTlsCipherPriority);
+
     void syncNetworkProcessCookies();
 
     void setShouldMakeNextWebProcessLaunchFailForTesting(bool value) { m_shouldMakeNextWebProcessLaunchFailForTesting = value; }


### PR DESCRIPTION
This implementation adds support for changing GNU TLS cipher priority in
runtime without Network Process reboot.