### PR TITLE
ONEM-21455: Query pipeline for seekable time range

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -103,7 +103,9 @@ public:
     void fillTimerFired();
 
     std::unique_ptr<PlatformTimeRanges> buffered() const override;
-    MediaTime maxMediaTimeSeekable() const override;
+    MediaTime maxMediaTimeSeekable() const override { return seekableTimeRange().second; }
+    MediaTime minMediaTimeSeekable() const override { return seekableTimeRange().first; }
+    std::pair<MediaTime, MediaTime> seekableTimeRange() const;
     bool didLoadingProgress() const override;
     unsigned long long totalBytes() const override;
     MediaTime maxTimeLoaded() const override;


### PR DESCRIPTION
Based on legacy wpe patch 0103.wpe_adaptive_demux_livestream.patch