### PR TITLE
[ONEM-22550] Rename webkitOfflineAudioContext API to OfflineAudioContext

### DIFF
--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.idl
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.idl
@@ -28,6 +28,6 @@
     Constructor(unsigned long numberOfChannels, unsigned long numberOfFrames, unrestricted float sampleRate),
     ConstructorMayThrowException,
     ConstructorCallWith=ScriptExecutionContext,
-    InterfaceName=webkitOfflineAudioContext
+    InterfaceName=OfflineAudioContext
 ] interface OfflineAudioContext : AudioContext {
 };


### PR DESCRIPTION
BBC ACT WebAudio testcases do not check for vendor prefix for
offline audio context.

Based on 0179.wpe_remove_prefix_from_OfflineAudioContext.patch (OMWAI-3199).