### PR TITLE
ONEM-21455: Query pipeline for seekable time range

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1724,18 +1724,33 @@ void MediaPlayerPrivateGStreamer::fillTimerFired()
     updateStates();
 }
 
-MediaTime MediaPlayerPrivateGStreamer::maxMediaTimeSeekable() const
+std::pair<MediaTime, MediaTime> MediaPlayerPrivateGStreamer::seekableTimeRange() const
 {
-    if (m_errorOccured)
-        return MediaTime::zeroTime();
+    auto query = adoptGRef(gst_query_new_seeking(GST_FORMAT_TIME));
 
-    MediaTime duration = durationMediaTime();
-    GST_DEBUG("maxMediaTimeSeekable, duration: %s", toString(duration).utf8().data());
-    // infinite duration means live stream
-    if (duration.isPositiveInfinite())
-        return MediaTime::zeroTime();
+    if (gst_element_query(m_pipeline.get(), query.get()))
+    {
+        gboolean seekable;
+        gint64 start, end;
 
-    return duration;
+        gst_query_parse_seeking(query.get(), NULL, &seekable, &start, &end);
+
+        if (seekable)
+        {
+            const auto range =
+                std::make_pair(MediaTime{start, GST_SECOND}, MediaTime{end, GST_SECOND});
+
+            GST_DEBUG_OBJECT(
+                m_pipeline.get(),
+                "seekable range <%f, %f)s",
+                range.first.toDouble(), range.second.toDouble());
+            return range;
+        } else
+            GST_WARNING_OBJECT(m_pipeline.get(), "not seekable stream");
+    } else
+        GST_ERROR_OBJECT(m_pipeline.get(), "seeking query failed");
+
+    return {MediaTime::zeroTime(), MediaTime::zeroTime()};
 }
 
 MediaTime MediaPlayerPrivateGStreamer::maxTimeLoaded() const

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -102,7 +102,9 @@ public:
     void fillTimerFired();
 
     std::unique_ptr<PlatformTimeRanges> buffered() const override;
-    MediaTime maxMediaTimeSeekable() const override;
+    MediaTime maxMediaTimeSeekable() const override { return seekableTimeRange().second; }
+    MediaTime minMediaTimeSeekable() const override { return seekableTimeRange().first; }
+    std::pair<MediaTime, MediaTime> seekableTimeRange() const;
     bool didLoadingProgress() const override;
     unsigned long long totalBytes() const override;
     MediaTime maxTimeLoaded() const override;


### PR DESCRIPTION
Based on legacy wpe patch 0103.wpe_adaptive_demux_livestream.patch