### PR TITLE
[ONEM-22550] Extend AudioContext sample rate range

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 RefPtr<AudioBuffer> AudioBuffer::create(unsigned numberOfChannels, size_t numberOfFrames, float sampleRate)
 {
-    if (sampleRate < 22050 || sampleRate > 96000 || numberOfChannels > AudioContext::maxNumberOfChannels() || !numberOfFrames)
+    if (!AudioContext::isSupportedSampleRate(sampleRate) || numberOfChannels > AudioContext::maxNumberOfChannels() || !numberOfFrames)
         return nullptr;
 
     auto buffer = adoptRef(*new AudioBuffer(numberOfChannels, numberOfFrames, sampleRate));

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -106,11 +106,9 @@ namespace WebCore {
 
 #define RELEASE_LOG_IF_ALLOWED(fmt, ...) RELEASE_LOG_IF(document()->page() && document()->page()->isAlwaysOnLoggingAllowed(), Media, "%p - AudioContext::" fmt, this, ##__VA_ARGS__)
     
-bool AudioContext::isSampleRateRangeGood(float sampleRate)
+bool AudioContext::isSupportedSampleRate(float sampleRate)
 {
-    // FIXME: It would be nice if the minimum sample-rate could be less than 44.1KHz,
-    // but that will require some fixes in HRTFPanner::fftSizeForSampleRate(), and some testing there.
-    return sampleRate >= 44100 && sampleRate <= 96000;
+    return sampleRate >= 3000 && sampleRate <= 384000;
 }
 
 // Don't allow more than this number of simultaneous AudioContexts talking to hardware.

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -264,11 +264,11 @@ public:
 
     void nodeWillBeginPlayback();
 
+    static bool isSupportedSampleRate(float sampleRate);
+
 protected:
     explicit AudioContext(Document&);
     AudioContext(Document&, unsigned numberOfChannels, size_t numberOfFrames, float sampleRate);
-    
-    static bool isSampleRateRangeGood(float sampleRate);
     
 private:
     void constructCommon();

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -42,7 +42,7 @@ ExceptionOr<Ref<OfflineAudioContext>> OfflineAudioContext::create(ScriptExecutio
     // FIXME: Add support for workers.
     if (!is<Document>(context))
         return Exception { NotSupportedError };
-    if (!numberOfChannels || numberOfChannels > 10 || !numberOfFrames || !isSampleRateRangeGood(sampleRate))
+    if (!numberOfChannels || numberOfChannels > 10 || !numberOfFrames || !isSupportedSampleRate(sampleRate))
         return Exception { SyntaxError };
     auto audioContext = adoptRef(*new OfflineAudioContext(downcast<Document>(context), numberOfChannels, numberOfFrames, sampleRate));
     audioContext->suspendIfNeeded();

--- a/Source/WebCore/platform/audio/FFTFrame.h
+++ b/Source/WebCore/platform/audio/FFTFrame.h
@@ -69,6 +69,9 @@ public:
     float* realData() const;
     float* imagData() const;
 
+    static int minFFTSize();
+    static int maxFFTSize();
+
     void print(); // for debugging
 
     // CROSS-PLATFORM

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -73,11 +73,32 @@ HRTFPanner::~HRTFPanner() = default;
 
 size_t HRTFPanner::fftSizeForSampleRate(float sampleRate)
 {
-    // The HRTF impulse responses (loaded as audio resources) are 512 sample-frames @44.1KHz.
-    // Currently, we truncate the impulse responses to half this size, but an FFT-size of twice impulse response size is needed (for convolution).
-    // So for sample rates around 44.1KHz an FFT size of 512 is good. We double the FFT-size only for sample rates at least double this.
-    ASSERT(sampleRate >= 44100 && sampleRate <= 96000.0);
-    return (sampleRate < 88200.0) ? 512 : 1024;
+    // The HRTF impulse responses (loaded as audio resources) are 512
+    // sample-frames @44.1KHz. Currently, we truncate the impulse responses to
+    // half this size, but an FFT-size of twice impulse response size is needed
+    // (for convolution). So for sample rates around 44.1KHz an FFT size of 512
+    // is good. For different sample rates, the truncated response is resampled.
+    // The resampled length is used to compute the FFT size by choosing a power
+    // of two that is greater than or equal the resampled length. This power of
+    // two is doubled to get the actual FFT size.
+
+    const int truncatedImpulseLength = 256;
+    double sampleRateRatio = sampleRate / 44100;
+    double resampledLength = truncatedImpulseLength * sampleRateRatio;
+
+    // This is the size used for analysis frames in the HRTF kernel. The
+    // convolvers used by the kernel are twice this size.
+    int analysisFFTSize = 1 << static_cast<unsigned>(log2(resampledLength));
+
+    // Don't let the analysis size be smaller than the supported size
+    analysisFFTSize = std::max(analysisFFTSize, FFTFrame::minFFTSize());
+
+    int convolverFFTSize = 2 * analysisFFTSize;
+
+    // Make sure this size of convolver is supported.
+    ASSERT(convolverFFTSize <= FFTFrame::maxFFTSize());
+
+    return convolverFFTSize;
 }
 
 void HRTFPanner::reset()

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -30,6 +30,10 @@
 
 namespace {
 
+// FIXME: It is unclear what the limits are for gst_fft so we use the same ones as on macOS for now.
+const int kMinFFTPow2Size = 2;
+const int kMaxFFTPow2Size = 24;
+
 size_t unpackedFFTDataSize(unsigned fftSize)
 {
     return fftSize / 2 + 1;
@@ -167,6 +171,16 @@ float* FFTFrame::realData() const
 float* FFTFrame::imagData() const
 {
     return const_cast<float*>(m_imagData.data());
+}
+
+int FFTFrame::minFFTSize()
+{
+    return 1 << kMinFFTPow2Size;
+}
+
+int FFTFrame::maxFFTSize()
+{
+    return 1 << kMaxFFTPow2Size;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
Solution based on upstream patch:
https://bugs.webkit.org/show_bug.cgi?id=215289

Based on 0185.wpe_audio_context_extend_sample_rate.patch (OMWAI-3199)