### PR TITLE
ONEM-21363: calculate the max time loaded base on network stats from webkitwebsrc element

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1516,12 +1516,9 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
                     // Update maxTimeLoaded only if the media duration is
                     // available. Otherwise we can't compute it.
                     if (mediaDuration && httpResponseTotalSize) {
-                        double fillStatus = 100.0 * (static_cast<double>(networkReadPosition) / static_cast<double>(httpResponseTotalSize));
+                        const double fillStatus = static_cast<double>(networkReadPosition) / static_cast<double>(httpResponseTotalSize);
 
-                        if (fillStatus == 100.0)
-                            m_maxTimeLoaded = mediaDuration;
-                        else
-                            m_maxTimeLoaded = MediaTime(fillStatus * static_cast<double>(toGstUnsigned64Time(mediaDuration)) / 100, GST_SECOND);
+                        m_maxTimeLoaded = MediaTime(fillStatus * static_cast<double>(toGstUnsigned64Time(mediaDuration)), GST_SECOND);
                         GST_DEBUG("Updated maxTimeLoaded base on network read position: %s", toString(m_maxTimeLoaded).utf8().data());
                     }
                 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -92,6 +92,29 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
 #include "CDMInstance.h"
 #endif
 
+namespace {
+
+bool isMediaDiskCacheDisabled()
+{
+    static bool result = false;
+    static bool computed = false;
+
+    if (computed)
+        return result;
+
+    String s(std::getenv("WPE_SHELL_DISABLE_MEDIA_DISK_CACHE"));
+    if (!s.isEmpty()) {
+        String value = s.stripWhiteSpace().convertToLowercaseWithoutLocale();
+        result = (value=="1" || value=="t" || value=="true");
+    }
+
+    GST_DEBUG("Media on-disk cache is %s", (result)?"disabled":"enabled");
+
+    computed = true;
+    return result;
+}
+}
+
 namespace WebCore {
 using namespace std;
 
@@ -1482,6 +1505,26 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
                 GstClockTime time;
                 gst_structure_get(structure, "uri", G_TYPE_STRING, &uri.outPtr(), "fragment-download-time", GST_TYPE_CLOCK_TIME, &time, nullptr);
                 GST_TRACE("Fragment %s download time %" GST_TIME_FORMAT, uri.get(), GST_TIME_ARGS(time));
+            } else if (isMediaDiskCacheDisabled() && gst_structure_has_name(structure, "webkit-network-statistics")) {
+                guint64 networkReadPosition = 0;
+                guint64 httpResponseTotalSize = 0;
+
+                if (gst_structure_get(structure, "read-position", G_TYPE_UINT64, &networkReadPosition, "size", G_TYPE_UINT64, &httpResponseTotalSize, nullptr)) {
+                    GST_DEBUG_OBJECT(pipeline(), "Updated network read position %" G_GUINT64_FORMAT ", size: %" G_GUINT64_FORMAT, networkReadPosition, httpResponseTotalSize);
+
+                    MediaTime mediaDuration = durationMediaTime();
+                    // Update maxTimeLoaded only if the media duration is
+                    // available. Otherwise we can't compute it.
+                    if (mediaDuration && httpResponseTotalSize) {
+                        double fillStatus = 100.0 * (static_cast<double>(networkReadPosition) / static_cast<double>(httpResponseTotalSize));
+
+                        if (fillStatus == 100.0)
+                            m_maxTimeLoaded = mediaDuration;
+                        else
+                            m_maxTimeLoaded = MediaTime(fillStatus * static_cast<double>(toGstUnsigned64Time(mediaDuration)) / 100, GST_SECOND);
+                        GST_DEBUG("Updated maxTimeLoaded base on network read position: %s", toString(m_maxTimeLoaded).utf8().data());
+                    }
+                }
             } else if (gst_structure_has_name(structure, "GstCacheDownloadComplete")) {
                 m_downloadFinished = true;
                 m_buffering = false;
@@ -2694,26 +2737,6 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
 #endif
 
     return extendedSupportsType(parameters, result);
-}
-
-bool isMediaDiskCacheDisabled()
-{
-    static bool result = false;
-    static bool computed = false;
-
-    if (computed)
-        return result;
-
-    String s(std::getenv("WPE_SHELL_DISABLE_MEDIA_DISK_CACHE"));
-    if (!s.isEmpty()) {
-        String value = s.stripWhiteSpace().convertToLowercaseWithoutLocale();
-        result = (value=="1" || value=="t" || value=="true");
-    }
-
-    GST_DEBUG("Media on-disk cache is %s", (result)?"disabled":"enabled");
-
-    computed = true;
-    return result;
 }
 
 void MediaPlayerPrivateGStreamer::setDownloadBuffering()

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -994,6 +994,9 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const c
         priv->size = priv->offset;
     }
 
+    gst_element_post_message(GST_ELEMENT_CAST(src), gst_message_new_element(GST_OBJECT_CAST(src),
+        gst_structure_new("webkit-network-statistics", "read-position", G_TYPE_UINT64, priv->offset, "size", G_TYPE_UINT64, priv->size, nullptr)));
+
     // Now split the recv'd buffer into buffers that are of a size basesrc suggests. It is important not
     // to push buffers that are too large, otherwise incorrect buffering messages can be sent from the
     // pipeline.


### PR DESCRIPTION
…webkitwebsrc element

This fix bases on the change from:
https://trac.webkit.org/changeset/243537/webkit

The original fix was aimed to fix the problem in case of HLS streams, while my implementation
fix the problem with the buffering level in case of progressive playback. It works only for
pipeline with WebkitWebSrc element and when the buffering on disk is disabled.