### PR TITLE
[ONEM-23251] WPE2.22 - memcheck tool should not be enabled by default on debug builds

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1596,10 +1596,6 @@ if (USE_LIBWEBRTC)
       )
 endif ()
 
-if (ENABLE_MEMCHECK)
-    list(APPEND WebCore_LIBRARIES memcheck)
-endif()
-
 set(WebCoreTestSupport_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/mock"
     "${WEBCORE_DIR}/testing"


### PR DESCRIPTION
… started

memcheck disabled by default.
It can be enabled with LD_PRELOAD env variable