### PR TITLE
[ONEM-21141] On frame url reload trigger image decoded data destruction

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1328,6 +1328,8 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
 
     Ref<Frame> protect(m_frame);
 
+    if(m_frame.document()) m_frame.document()->cachedResourceLoader().destroyImagesDecodedData();
+
     String frameName = frameLoadRequest.frameName();
     AllowNavigationToInvalidURL allowNavigationToInvalidURL = frameLoadRequest.allowNavigationToInvalidURL();
     NewFrameOpenerPolicy openerPolicy = frameLoadRequest.newFrameOpenerPolicy();
@@ -1335,6 +1337,13 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     bool isFormSubmission = formState;
 
     const URL& newURL = frameLoadRequest.resourceRequest().url();
+
+    LOG(
+            Loading,
+            "%s:%d %s %s",
+            ::basename(__FILE__), __LINE__, __FUNCTION__,
+            newURL.string().utf8().data());
+
     ResourceRequest request(newURL);
     if (!referrer.isEmpty()) {
         request.setHTTPReferrer(referrer);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -99,6 +99,7 @@ public:
 #if ENABLE(APPLICATION_MANIFEST)
     ResourceErrorOr<CachedResourceHandle<CachedApplicationManifest>> requestApplicationManifest(CachedResourceRequest&&);
 #endif
+    void destroyImagesDecodedData();
 
     // Called to load Web Worker main script, Service Worker main script, importScripts(), XHR,
     // EventSource, Fetch, and App Cache.


### PR DESCRIPTION
Based on legacy wpe patch 0204.wpe_destroy_decoded_img_data_on_url_load.patch