### PR TITLE
[ONEM-22718] Avoid sending waiting event on playback rate related seek

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1116,6 +1116,7 @@ void HTMLMediaElement::mediaPlayerActiveSourceBuffersChanged(const MediaPlayer*)
 void HTMLMediaElement::scheduleEvent(const AtomicString& eventName)
 {
     RefPtr<Event> event = Event::create(eventName, Event::CanBubble::No, Event::IsCancelable::Yes);
+    DEBUG_LOG(LOGIDENTIFIER, "scheduleEvent: ", eventName);
 
     // Don't set the event target, the event queue will set it in GenericEventQueue::timerFired and setting it here
     // will trigger an ASSERT if this element has been marked for deletion.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -677,6 +677,10 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
         case GST_STATE_PAUSED:
         case GST_STATE_PLAYING:
             if (seeking()) {
+              GST_DEBUG("early seek check");
+              maybeFinishSeek();
+            }
+            if (seeking()) {
                 m_readyState = MediaPlayer::HaveMetadata;
                 // FIXME: Should we manage NetworkState too?
                 GST_DEBUG("m_readyState=%s", dumpReadyState(m_readyState));
@@ -801,6 +805,7 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
 }
 void MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone()
 {
+    GST_DEBUG("async state change done");
     if (UNLIKELY(!m_pipeline || m_errorOccured))
         return;
 


### PR DESCRIPTION
It is matter of race result if seek completion is already detected.
Some applications do not recover from waiting event without additional
seeked or palying, but these do not follow on playback rate change.