### PR TITLE
[ONEM-23447] Send close notification on window.close()

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1091,8 +1091,10 @@ void DOMWindow::close()
 
     bool allowScriptsToCloseWindows = m_frame->settings().allowScriptsToCloseWindows();
 
-    if (!(page->openedByDOM() || page->backForward().count() <= 1 || allowScriptsToCloseWindows)) {
-        console()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
+    // Make allowScriptsToCloseWindow pref value take precedence when closing window
+    if (!allowScriptsToCloseWindows || !(page->openedByDOM() || page->backForward().count() <= 1)) {
+        // Send close notification to give a chance for AWC to react on window.close()
+        page->chrome().closeWindowSoon();
         return;
     }
 


### PR DESCRIPTION
Send close notification even when 'allowScriptsToCloseWindow' preference
is not set.
This patch is based on following legacy changes:
* https://github.com/LibertyGlobal/wpe-webkit/commit/1bf6ab0bcaea3651ad67402218ebd6e94dc7eea3
* 0158.window_close.patch
https://jira.lgi.io/browse/ARRISEOS-7820
https://jira.lgi.io/browse/ARRISEOS-34237