### PR TITLE
[ARRISEOS-40758] Use Widget bounds for PlatformScreen rectangle information

### DIFF
--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -28,6 +28,7 @@
 
 #include "FloatRect.h"
 #include "NotImplemented.h"
+#include "Widget.h"
 
 namespace WebCore {
 
@@ -65,16 +66,19 @@ void setScreenDPIObserverHandler(Function<void()>&&, void*)
     notImplemented();
 }
 
-FloatRect screenRect(Widget*)
+FloatRect screenRect(Widget* widget)
 {
-    notImplemented();
-    return FloatRect(0, 0, 1024, 640);
+    // WPE can't offer any more useful information about the screen size,
+    // so we use the Widget's bounds rectangle (size of which equals the WPE view size).
+
+    if (!widget)
+        return { };
+    return widget->boundsRect();
 }
 
-FloatRect screenAvailableRect(Widget*)
+FloatRect screenAvailableRect(Widget* widget)
 {
-    notImplemented();
-    return FloatRect(0, 0, 1024, 640);
+    return screenRect(widget);
 }
 
 bool screenSupportsExtendedColor(Widget*)


### PR DESCRIPTION
This is a backport of WebKit change described below. It is neeeded for
BritBox, which  uses |window.screen.availHeight| JS API to make sure that
VirginMedia app version will fit into the screen. If returned value is less
than 1080, it falls back to the FVP app version with native DASH playback.

https://bugs.webkit.org/show_bug.cgi?id=193190

Provide a better screen area estimate in screenRect() and
screenAvailableRect() return values than the current 1240x640 value by
using the Widget's bounds rectangle.

This approach is only factually correct when the Widget-associated view
is displayed in fullscreen, but it provides a better estimate even when
displayed in any other case as well. WPE doesn't provide specific API
that could enable the embedding environment to provide this information.
