### PR TITLE
[ARRISEOS-41251] Limit number of active GraphicsContexts to only one instance

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/GraphicsContext3DTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContext3DTextureMapper.cpp
@@ -59,10 +59,10 @@
 
 namespace WebCore {
 
-static const size_t MaxActiveContexts = 16;
-static Deque<GraphicsContext3D*, MaxActiveContexts>& activeContexts()
+static const size_t MaxActiveContexts = 1;
+static Deque<GraphicsContext3D*>& activeContexts()
 {
-    static NeverDestroyed<Deque<GraphicsContext3D*, MaxActiveContexts>> s_activeContexts;
+    static NeverDestroyed<Deque<GraphicsContext3D*>> s_activeContexts;
     return s_activeContexts;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContext3DTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContext3DTextureMapper.cpp
@@ -59,6 +59,7 @@
 
 namespace WebCore {
 
+// ARRISEOS-41251: limit number of active GraphicsContexts to only one instance
 static const size_t MaxActiveContexts = 1;
 static Deque<GraphicsContext3D*>& activeContexts()
 {


### PR DESCRIPTION
Reducing maximum number of GraphicsContexts from 16 to 1 is significantly reducing needed GFX memory for Lightning apps. 
If we want to create new GraphicsContexts (it's done for each Metro Lightning app launch), then previous context is removed.

Solution still needs improvements: after exit from Metro app to BootURL, all the time app GraphicsContexts is active. That context also must be removed. 