### PR TITLE
[ARRISEOS-40788] - disable async decoding big picture by env var

### DIFF
--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -350,6 +350,14 @@ bool RenderBoxModelObject::hasAutoHeightOrContainingBlockWithAutoHeight() const
 
 DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, const PaintInfo& paintInfo) const
 {
+    static bool largeImageAsyncDecodingDisabledByEnvVar = false;
+    static bool largeImageAsyncDecodingDisabledByEnvVarInitialized = false;
+
+    if (!largeImageAsyncDecodingDisabledByEnvVarInitialized) {
+        largeImageAsyncDecodingDisabledByEnvVar = !!getenv("WPE_DISABLE_ASYNC_DECODING_LARGE_IMAGES");
+        largeImageAsyncDecodingDisabledByEnvVarInitialized = true;
+    }
+
     if (!is<BitmapImage>(image))
         return DecodingMode::Synchronous;
     
@@ -375,6 +383,8 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
     if (document().isImageDocument())
         return DecodingMode::Synchronous;
     if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
+        return DecodingMode::Synchronous;
+    if (largeImageAsyncDecodingDisabledByEnvVar)
         return DecodingMode::Synchronous;
     if (!settings().largeImageAsyncDecodingEnabled())
         return DecodingMode::Synchronous;


### PR DESCRIPTION
The change is taken from the upstream: https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/48aa792b6d9b8bdd21cbda7825013f439fb82866