### PR TITLE
[ARRISEOS-40859] Set SOUP_SESSION_TIMEOUT to 60 seconds

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -132,6 +132,7 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID, SoupCookieJar* 
         SOUP_SESSION_USE_THREAD_CONTEXT, TRUE,
         SOUP_SESSION_SSL_USE_SYSTEM_CA_FILE, TRUE,
         SOUP_SESSION_SSL_STRICT, TRUE,
+        SOUP_SESSION_TIMEOUT, 60,
         nullptr);
 
     setupCustomProtocols();


### PR DESCRIPTION
Before this commit the default value of 0 was used, which means that
libsoup's network requests did not timeout at all.

This commit sets libsoup's socket timeout to 60. Failed request will
emit "Socket I/O timed out" error to the application. The error will be
also visible in WebKit logs.