### PR TITLE
[ARRISAPOL-2261] Report buffering level based on brcmvidfilter reporting

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1402,6 +1402,13 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         }
 #endif
 
+#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
+        if (currentState == GST_STATE_NULL && newState == GST_STATE_READY && g_strstr_len(GST_MESSAGE_SRC_NAME(message), 13, "brcmvidfilter"))
+            m_vidfilter = GST_ELEMENT(GST_MESSAGE_SRC(message));
+        else if (currentState == GST_STATE_READY && newState == GST_STATE_NULL && g_strstr_len(GST_MESSAGE_SRC_NAME(message), 13, "brcmvidfilter"))
+            m_vidfilter = nullptr;
+#endif
+
         if (!messageSourceIsPlaybin || m_delayingLoad)
             break;
         updateStates();
@@ -1621,6 +1628,24 @@ void MediaPlayerPrivateGStreamer::processBufferingStats(GstMessage* message)
 
     m_buffering = true;
     gst_message_parse_buffering(message, &m_bufferingPercentage);
+
+#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
+    // The Nexus playpump buffers a lot of data. Let's add it as if it had been buffered by the GstQueue2
+    // (only when using in-memory buffering), so we get more realistic percentages.
+    if (!m_downloadBuffer && m_vidfilter) {
+        GstObject *queue2 = GST_MESSAGE_SRC(message);
+        guint maxSizeBytes = 0;
+        // Current-level-bytes seems to be inacurate, so we compute its value from the buffering percentage
+        g_object_get(queue2, "max-size-bytes", &maxSizeBytes, nullptr);
+
+        guint playpumpBufferedBytes = 0;
+        g_object_get(GST_OBJECT(m_vidfilter.get()), "buffered-bytes", &playpumpBufferedBytes, nullptr);
+
+        size_t currentLevelBytes = (size_t)maxSizeBytes * (size_t)m_bufferingPercentage / (size_t)100 + (size_t)playpumpBufferedBytes;
+        m_bufferingPercentage = currentLevelBytes > maxSizeBytes ? 100 : (int)(currentLevelBytes * 100 / maxSizeBytes);
+        GST_DEBUG("[Buffering] Buffering: %d%% (corrected with playpump content).", m_bufferingPercentage);
+    } else
+#endif
 
     GST_DEBUG("[Buffering] Buffering: %d%%.", m_bufferingPercentage);
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -315,6 +315,10 @@ private:
     HashMap<AtomicString, RefPtr<InbandMetadataTextTrackPrivateGStreamer>> m_metadataTracks;
 #endif
 #endif
+#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
+    GRefPtr<GstElement> m_vidfilter;
+#endif
+
     DemuxMonitor _demuxMonitor;
     virtual bool isMediaSource() const { return false; }
 


### PR DESCRIPTION
MediaPlayerPrivateGStreamer starts playback when buffering level reaches
100% the first time. Buffering level is computed only based on GstQueue2
reporting. This is wrong, because there are more queues further in the
pipeline, which drain GstQueue2 out of data as soon as they can. This
causes slow start of progresive videos, especially on slow connections.

This patch modifies this algorithm and takes into account how much data
was buffered in brcmvidfilter.

Based on this upstream patch:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/14f712084b349ab70e87352d73dc02ee42c1a99e