### PR TITLE
[ARRISEOS-41524] Fix OOM caused by excessive buffering in progressive

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -722,37 +722,31 @@ static void webKitWebSrcUriHandlerInit(gpointer gIface, gpointer)
 
 static void webKitWebSrcNeedData(WebKitWebSrc* src)
 {
-    WebKitWebSrcPrivate* priv = src->priv;
-
     GST_LOG_OBJECT(src, "Need more data");
-
-    if (!priv->paused)
-        return;
-    priv->paused = false;
-
     GRefPtr<WebKitWebSrc> protector = WTF::ensureGRef(src);
-    priv->notifier->notify(MainThreadSourceNotification::NeedData, [protector] {
+    src->priv->notifier->notify(MainThreadSourceNotification::NeedData, [protector] {
         WebKitWebSrcPrivate* priv = protector->priv;
-        if (priv->resource)
-            priv->resource->setDefersLoading(false);
+        if (priv->paused) {
+            GST_DEBUG_OBJECT(protector.get(), "Unpausing data loader");
+            priv->paused = false;
+            if (priv->resource)
+                priv->resource->setDefersLoading(false);
+        }
     }, true);
 }
 
 static void webKitWebSrcEnoughData(WebKitWebSrc* src)
 {
-    WebKitWebSrcPrivate* priv = src->priv;
-
-    GST_DEBUG_OBJECT(src, "Have enough data");
-
-    if (priv->paused)
-        return;
-    priv->paused = true;
-
+    GST_LOG_OBJECT(src, "Have enough data");
     GRefPtr<WebKitWebSrc> protector = WTF::ensureGRef(src);
-    priv->notifier->notify(MainThreadSourceNotification::EnoughData, [protector] {
+    src->priv->notifier->notify(MainThreadSourceNotification::EnoughData, [protector] {
         WebKitWebSrcPrivate* priv = protector->priv;
-        if (priv->resource)
-            priv->resource->setDefersLoading(true);
+        if (!priv->paused) {
+            GST_DEBUG_OBJECT(protector.get(), "Pausing data loader");
+            priv->paused = true;
+            if (priv->resource)
+                priv->resource->setDefersLoading(true);
+        }
     }, true);
 }
 


### PR DESCRIPTION
This commit is basically a continuation of
57bbecb9421d206f40a3beb45b9d800288a39b1d, which did not fully fix the
original issue.

webKitWebSrcEnoughData and webKitWebSrcNeedData are used to pause and unpause
the stream fetching procedure ongoing on the network process. Both functions
operate on the same |paused| variable, but webKitWebSrcNeedData is
called on different thread. This is essentially a data race, which may lead to
incorrect flag state. Flow required for issue reproduction goes like this:

Streaming thread           Main thread
       |                        |
webKitWebSrcNeedData() webKitWebSrcEnoughData()
       |                    paused=true
       |               setDefersLoading(false)
       |                        |
   paused=false                 |
       |                        |
       |               webKitWebSrcEnoughData()
       |                    paused=true
       |               setDefersLoading(false)
       |                        |
       |               // Scheduled from Streaming thread
       |               setDefersLoading(false)

As a result, |paused=true|, but the network process is not actually paused.
It will keep sending data to the web process, which will push it to appsrc, the
memory used by appsrc will grow with no limit and the process will eventually
cause an out of memory (OOM) error.

The solution is to always use the |paused| flag on Main thread.