### PR TITLE
[ARRISEOS-40859][SoupNetworkSession] Drop open connections on network change

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -34,6 +34,7 @@
 #include "GUniquePtrSoup.h"
 #include "Logging.h"
 #include "SoupNetworkProxySettings.h"
+#include <gio/gio.h>
 #include <glib/gstdio.h>
 #include <libsoup/soup.h>
 #include <pal/crypto/CryptoDigest.h>
@@ -106,6 +107,11 @@ static HashMap<String, HostTLSCertificateSet, ASCIICaseInsensitiveHash>& clientC
     return certificates;
 }
 
+static void networkDidChange(GNetworkMonitor*, gboolean, SoupNetworkSession* session)
+{
+    soup_session_abort(session->soupSession());
+}
+
 SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID, SoupCookieJar* cookieJar)
     : m_soupSession(adoptGRef(soup_session_async_new()))
 {
@@ -153,9 +159,14 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID, SoupCookieJar* 
     if (proxySettings().mode != SoupNetworkProxySettings::Mode::Default)
         setupProxy();
     setupLogger();
+
+    g_signal_connect(g_network_monitor_get_default(), "network-changed", G_CALLBACK(networkDidChange), this);
 }
 
-SoupNetworkSession::~SoupNetworkSession() = default;
+SoupNetworkSession::~SoupNetworkSession()
+{
+    g_signal_handlers_disconnect_by_func(g_network_monitor_get_default(), reinterpret_cast<gpointer>(networkDidChange), this);
+}
 
 void SoupNetworkSession::setupLogger()
 {


### PR DESCRIPTION
This is a downstream of:
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/43877edc4454aa4c7e4073aa6658cedfb62756f1

Libsoup internally creates sockets and tries to keep them alive for the sake
of incoming request to the same host. It works just fine, unless the network
change occurs in the meantime. In such case, libsoup does not drop the active
connection automatically.

This change introduces network change detection, which triggers
soup_session_abort and closes the hanged sockets.