### PR TITLE
ARRISEOS-41603: Skip updateStates call on reaching end of looped video

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2554,13 +2554,16 @@ void MediaPlayerPrivateGStreamer::didEnd()
         m_player->durationChanged();
 
     m_isEndReached = true;
-    timeChanged();
 
     if (!m_player->client().mediaPlayerIsLooping()) {
+        timeChanged();
         m_paused = true;
         m_durationAtEOS = durationMediaTime();
         changePipelineState(GST_STATE_READY);
         m_downloadFinished = false;
+    } else {
+        // Skip updateStates() as that would eventually result in play(), clearing m_isEndReached
+        m_player->timeChanged();
     }
 }
 


### PR DESCRIPTION
updateStates would trigger play() call, clearing m_isEndReached and changing reported position