### PR TITLE
[ONEM-25455] Fix memcheck tool for WPE 2.22

### DIFF
--- a/Source/ThirdParty/memcheck/CMakeLists.txt
+++ b/Source/ThirdParty/memcheck/CMakeLists.txt
@@ -9,5 +9,5 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fasynchronous-unwind-tables")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funwind-tables")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
 
-add_library(memcheck SHARED ${MEMCHECK_SOURCES})
-target_link_libraries(memcheck dl pthread)
+add_library(memcheckthunder SHARED ${MEMCHECK_SOURCES})
+target_link_libraries(memcheckthunder dl pthread)

--- a/Source/ThirdParty/memcheck/src/memcheck.c
+++ b/Source/ThirdParty/memcheck/src/memcheck.c
@@ -1,15 +1,20 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <dlfcn.h>
 #include <execinfo.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 // memcheck will create report for each process
@@ -25,116 +30,132 @@
 // (e.g. video may not play, due to memcheck overhead)
 static unsigned memcheck_size_min = 16 * 1024;
 static unsigned memcheck_size_max = 4 * 1024 * 1024;
-static unsigned int startup_delay_in_sec = 30;
+static int startup_delay_in_sec = 30;
+static unsigned int end_delay_in_sec = 30;
 static unsigned int memcheck_duration = 30;
 
 static char calloc_buffer[TMP_CALLOC_BUFF];
 static int calloc_buffer_offset = 0;
 static int calloc_buffer_nb = 0;
-static unsigned int memory_trace_max_cnt = 0;
 static unsigned int memory_trace_enabled = 0;
 static unsigned int memory_trace_free_enabled = 0;
-static unsigned int memory_trace_skip = 0;
-static unsigned int my_malloc_cnt = 0;
-static unsigned int my_calloc_cnt = 0;
-static unsigned int my_free_cnt = 0;
-static unsigned int my_realloc_cnt = 0;
+static uint64_t my_malloc_cnt = 0;
+static uint64_t malloc_total_size = 0;
+static uint64_t malloc_total = 0;
+static uint64_t my_free_cnt = 0;
+static uint64_t free_total_size = 0;
+static uint64_t free_total = 0;
+static uint64_t my_calloc_cnt = 0;
+static uint64_t my_realloc_cnt = 0;
+static int collect_callstack = 0;
+static struct timeval start_time;
 
 typedef struct {
-    void * address;
+    void *address;
     size_t size;
-    unsigned thread_id;
+    pthread_t tid;
     int call_stack_nb;
     void* call_stack[MAX_CALLSTACK + 1];
+    struct timeval timestamp;
 } memory_trace_t;
 
 static memory_trace_t memory_trace[MAX_TRACE];
 static pthread_mutex_t memory_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 void memcheck_control_start() {
-    fprintf(stderr, "memcheck: memcheck_control_start from pid: %d\n", getpid());
+    fprintf(stderr, "%s:%d pid: %d\n", __FUNCTION__, __LINE__, getpid());
     pthread_mutex_lock(&memory_lock);
+    gettimeofday(&start_time, NULL);
     memory_trace_enabled = 1;
     memory_trace_free_enabled = 1;
     pthread_mutex_unlock(&memory_lock);
 }
 
 void memcheck_control_stop() {
-    fprintf(stderr, "memcheck: memcheck_control_stop from pid: %d\n", getpid());
+    fprintf(stderr, "%s:%d pid: %d\n", __FUNCTION__, __LINE__, getpid());
     pthread_mutex_lock(&memory_lock);
     memory_trace_enabled = 0;
     memory_trace_free_enabled = 1;
     pthread_mutex_unlock(&memory_lock);
 }
 
-char* get_file_name_with_pid(int pid) {
-    char extension[8];
-    sprintf(extension, "%d", pid);
-    const char* file = "/tmp/wpe/memcheck-info_";
-    char* file_with_pid = malloc(strlen(file) + 8 + 1);
-
-    strcpy(file_with_pid, file);
-    strcat(file_with_pid, extension);
-
-    fprintf(stderr, "memcheck: get_file_name_with_pid file_with_pid: %s\n", file_with_pid);
-    return file_with_pid;
-}
-
 void memcheck_control_show() {
     int pid = getpid();
-    fprintf(stderr, "memcheck: memcheck_control_show from pid: %d\n", pid);
+    fprintf(stderr, "%s:%d pid %d\n", __FUNCTION__, __LINE__, pid);
 
-    char* path = get_file_name_with_pid(pid);
-    FILE* file = fopen(path, "wb");
+    char path[64] = {0};
+
+    snprintf(path, sizeof(path), "/tmp/wpe/memcheck-info_%d", pid);
+    FILE* file = fopen(path, "a");
+
     if (!file) {
+        fprintf(stderr, "%s:%d Failed to open file: %s\n", __FUNCTION__, __LINE__, path);
         return;
     }
 
-    unsigned i;
-    int j;
-    unsigned int cnt = 0;
+    struct timeval now;
+
+    gettimeofday(&now, NULL);
+
+    int cntr = 0;
+    const uint64_t offset_ms = ((uint64_t)start_time.tv_sec * 1000) + start_time.tv_usec / 1000;
+    const uint64_t now_ms = ((uint64_t)now.tv_sec * 1000) + now.tv_usec / 1000;
 
     pthread_mutex_lock(&memory_lock);
-    memory_trace_enabled = 0;
-    memory_trace_free_enabled = 0;
-    pthread_mutex_unlock(&memory_lock);
 
-    for (i = 0; i < memory_trace_max_cnt; ++i) {
-        if (memory_trace[i].address != (void*) 0) {
-            fprintf(file, "memcheck address: %p, allocation size: %zu, thread id: %d\n",
-                    memory_trace[i].address, memory_trace[i].size, memory_trace[i].thread_id);
+    for (int i = 0; i < MAX_TRACE; ++i) {
+        if (memory_trace[i].address == NULL) continue;
 
-            if (getenv("WPE_MEMCHECK_CALLSTACK")) {
-                char** s_callstack;
-                s_callstack = backtrace_symbols(memory_trace[i].call_stack, MAX_CALLSTACK);
-                if (s_callstack) {
-                    for (j = 0; j < memory_trace[i].call_stack_nb; ++j) {
-                        if (memory_trace[i].call_stack[j]) {
-                            fprintf(file, "  %p(%s)\n", memory_trace[i].call_stack[j], s_callstack[j]);
-                        } else {
-                            break;
-                        }
-                    }
-                    free(s_callstack);
-                }
+        char tname[32] = {0};
+
+        pthread_getname_np(memory_trace[i].tid, tname, sizeof(tname));
+        uint64_t ts_ms =
+            ((uint64_t)memory_trace[i].timestamp.tv_sec * 1000)
+            + memory_trace[i].timestamp.tv_usec / 1000 - offset_ms;
+
+        fprintf(file, "ts: %" PRIu64 " addr: %8p, size: %9zu, tid: %s",
+                ts_ms, memory_trace[i].address, memory_trace[i].size, tname);
+
+        cntr++;
+
+        if(collect_callstack) {
+            for (int j = 0; j < memory_trace[i].call_stack_nb; ++j) {
+                fprintf(file, " %p", memory_trace[i].call_stack[j]);
             }
-            cnt++;
-            memory_trace[i].address = (void*) 0;
         }
+        fprintf(file, "\n");
     }
-    fprintf(file, "memcheck statistics: malloc:%d calloc:%d realloc:%d free:%d max_depth:%d not_released:%d\n",
-            my_malloc_cnt, my_calloc_cnt, my_realloc_cnt, my_free_cnt, memory_trace_max_cnt, cnt);
-    fprintf(file, "memcheck statistics: tmp calloc %d %d\n", calloc_buffer_offset, calloc_buffer_nb);
-    fclose(file);
-    free(path);
 
-    pthread_mutex_lock(&memory_lock);
-    my_malloc_cnt = 0;
-    my_calloc_cnt = 0;
-    my_realloc_cnt = 0;
-    my_free_cnt = 0;
-    memory_trace_max_cnt = 0;
     pthread_mutex_unlock(&memory_lock);
+
+    fprintf(
+            file,
+            "ts: %" PRIu64
+            "ms %6d"
+            " malloc_total_size:%" PRIu64
+            " malloc:%" PRIu64
+            " calloc:%" PRIu64
+            " realloc:%" PRIu64
+            " free_total_size:%" PRIu64
+            " free:%" PRIu64
+            " total: %" PRId64
+            " total_size: %" PRId64
+            "\n",
+            now_ms - offset_ms,
+            cntr,
+            malloc_total_size,
+            my_malloc_cnt,
+            my_calloc_cnt,
+            my_realloc_cnt,
+            free_total_size,
+            my_free_cnt,
+            (int64_t)malloc_total - (int64_t)free_total,
+            (int64_t)malloc_total_size - (int64_t)free_total_size);
+
+    fprintf(stderr, "%s%d ts: %" PRIu64 "ms stats: tmp calloc %d %d\n",
+            __FUNCTION__, __LINE__,
+            now_ms - offset_ms, calloc_buffer_offset, calloc_buffer_nb);
+    fclose(file);
 }
 
 void memcheck_configuration() {
@@ -148,28 +169,58 @@ void memcheck_configuration() {
         memcheck_size_min = strtol(min_size, NULL, 10);
     }
 
-    const char* delay = getenv("WPE_MEMCHECK_STARTUP_DELAY");
-    if (delay) {
-        startup_delay_in_sec = strtol(delay, NULL, 10);
+    const char* start_delay = getenv("WPE_MEMCHECK_STARTUP_DELAY");
+    if (start_delay) {
+        startup_delay_in_sec = strtol(start_delay, NULL, 10);
+    }
+
+    const char* end_delay = getenv("WPE_MEMCHECK_END_DELAY");
+    if (end_delay) {
+        end_delay_in_sec = strtol(end_delay, NULL, 10);
     }
 
     const char* duration = getenv("WPE_MEMCHECK_DURATION");
     if (duration) {
         memcheck_duration = strtol(duration, NULL, 10);
     }
+    const char *callstack = getenv("WPE_MEMCHECK_CALLSTACK");
+    if(callstack) {
+        collect_callstack = !!atoi(callstack);
+    }
 }
 
 void* memcheck_control(void* not_used) {
+    (void)not_used;
     memcheck_configuration();
 
-    fprintf(stderr, "memcheck: memcheck for pid: %d will start in: %d sec, will last: %d sec, allocation range: [%d B, %d B], not_used: %p\n",
-            getpid(), startup_delay_in_sec, memcheck_duration, memcheck_size_min, memcheck_size_max, not_used);
+    fprintf(stderr, "%s:%d pid: %d will start in: %d sec, will last: %d sec, allocation range: [%d B, %d B]\n",
+            __FUNCTION__, __LINE__,
+            getpid(), startup_delay_in_sec, memcheck_duration, memcheck_size_min, memcheck_size_max);
+
+
+    struct timeval timestamp;
+    gettimeofday(&timestamp, NULL);
+
+    for(;;)
+    {
+        sleep(startup_delay_in_sec);
+        struct timeval now;
+        gettimeofday(&now, NULL);
+        if(startup_delay_in_sec <= now.tv_sec - timestamp.tv_sec) break;
+    }
+
 
     sleep(startup_delay_in_sec);
+
     memcheck_control_start();
-    sleep(memcheck_duration);
+
+    for(;;)
+    {
+        sleep(memcheck_duration);
+        memcheck_control_show();
+    }
+
     memcheck_control_stop();
-    memcheck_control_show();
 
     return NULL;
 }
@@ -192,53 +243,49 @@ bool create_memcheck_thread() {
 
 void* malloc(size_t size) {
     static void* (*libc_malloc)(size_t) = NULL;
-    void * result;
-    unsigned i;
+    void * result = NULL;
 
     pthread_mutex_lock(&memory_lock);
     if (!libc_malloc) {
         libc_malloc = (void* (*)(size_t)) dlsym(RTLD_NEXT, "malloc");
 
         // start memcheck control thread
-        if (!create_memcheck_thread()) {
-            pthread_mutex_unlock(&memory_lock);
-            return (void*) 0;
-        }
+        if (!create_memcheck_thread()) goto done;
     }
 
     result = libc_malloc(size);
+    malloc_total_size += size;
+    ++malloc_total;
 
-    if (!memory_trace_enabled || memory_trace_skip) {
-        pthread_mutex_unlock(&memory_lock);
-        return result;
-    }
+    if (!memory_trace_enabled) goto done;
 
     if (result && (size >= memcheck_size_min && size <= memcheck_size_max)) {
-        for (i = 0; i < MAX_TRACE; ++i) {
-            if (memory_trace[i].address == ((void*) 0)) {
-                memory_trace[i].address = (void*) result;
+
+        struct timeval timestamp;
+
+        gettimeofday(&timestamp, NULL);
+
+        for (int i = 0; i < MAX_TRACE; ++i) {
+            if (memory_trace[i].address == NULL) {
+                memory_trace[i].address = result;
                 memory_trace[i].size = size;
-                memory_trace[i].thread_id = syscall(__NR_gettid);
-                if (getenv("WPE_MEMCHECK_CALLSTACK")) {
+                memory_trace[i].tid = pthread_self();
+                memory_trace[i].timestamp = timestamp;
+                if (collect_callstack) {
                     /*
                     when backtrace size is equal to 1 then most probably the function that trigger our malloc wrapper is
                     compiled without appropriate flags (-rdynamic, -fasynchronous-unwind-tables, -funwind-tables) that allow
                     backtrace() to find previous stackframes
                     the same behavior applies to calloc() and realloc() wrappers
                     */
-                    memory_trace_skip = 1; // bactrace call will use malloc() function
                     memory_trace[i].call_stack_nb = backtrace(memory_trace[i].call_stack, MAX_CALLSTACK);
-                    memory_trace_skip = 0;
-                }
-                if (i >= memory_trace_max_cnt) {
-                    memory_trace_max_cnt = i + 1;
                 }
                 my_malloc_cnt++;
-                break;
+                goto done;
             }
         }
     }
-
+done:
     pthread_mutex_unlock(&memory_lock);
     return result;
 }
@@ -280,7 +327,7 @@ void* calloc(size_t nmemb, size_t size) {
     void* result;
     // need to prevent gcc compiler optimizations
     static volatile int calloc_init = 0;
-    unsigned i;
+    int i;
 
     pthread_mutex_lock(&memory_lock);
     if (calloc_init) {
@@ -297,24 +344,24 @@ void* calloc(size_t nmemb, size_t size) {
 
     result = libc_calloc(nmemb, size);
 
-    if (!memory_trace_enabled || memory_trace_skip) {
+    if (!memory_trace_enabled) {
         pthread_mutex_unlock(&memory_lock);
         return result;
     }
 
     if (result && (size >= memcheck_size_min && size <= memcheck_size_max)) {
+        struct timeval timestamp;
+
+        gettimeofday(&timestamp, NULL);
+
         for (i = 0; i < MAX_TRACE; ++i) {
-            if (memory_trace[i].address == ((void*) 0)) {
-                memory_trace[i].address = (void*) result;
+            if (memory_trace[i].address == NULL) {
+                memory_trace[i].address = result;
                 memory_trace[i].size = size;
-                memory_trace[i].thread_id = syscall(__NR_gettid);
-                if (getenv("WPE_MEMCHECK_CALLSTACK")) {
-                    memory_trace_skip = 1;
+                memory_trace[i].tid = pthread_self();
+                memory_trace[i].timestamp = timestamp;
+                if (collect_callstack) {
                     memory_trace[i].call_stack_nb = backtrace(memory_trace[i].call_stack, MAX_CALLSTACK);
-                    memory_trace_skip = 0;
-                }
-                if (i >= memory_trace_max_cnt) {
-                    memory_trace_max_cnt = i + 1;
                 }
                 my_calloc_cnt++;
                 break;
@@ -328,8 +375,7 @@ void* calloc(size_t nmemb, size_t size) {
 
 void* realloc(void* ptr, size_t size) {
     static void* (*libc_realloc)(void* , size_t) = NULL;
-    void * result;
-    unsigned i;
+    void * result = NULL;
 
     pthread_mutex_lock(&memory_lock);
     if (!libc_realloc) {
@@ -345,12 +391,9 @@ void* realloc(void* ptr, size_t size) {
     } else {
         result = libc_realloc(ptr, size);
         if (memory_trace_free_enabled) {
-            for (i = 0; i < memory_trace_max_cnt; i++) {
-                if (memory_trace[i].address == ((void * ) ptr)) {
-                    memory_trace[i].address = (void * ) 0;
-                    if ((i + 1) == memory_trace_max_cnt) {
-                        memory_trace_max_cnt--;
-                    }
+            for (int i = 0; i < MAX_TRACE; i++) {
+                if (memory_trace[i].address == ptr) {
+                    memory_trace[i].address = NULL;
                     my_free_cnt++;
                     break;
                 }
@@ -358,60 +401,55 @@ void* realloc(void* ptr, size_t size) {
         }
     }
 
-    if (!memory_trace_enabled || memory_trace_skip) {
-        pthread_mutex_unlock(&memory_lock);
-        return result;
-    }
+    if (!memory_trace_enabled) goto done;
 
     if (result && (size >= memcheck_size_min && size <= memcheck_size_max)) {
-        for (i = 0; i < MAX_TRACE; i++) {
-            if (memory_trace[i].address == (void*) 0) {
-                memory_trace[i].address = (void*) result;
+        struct timeval timestamp;
+
+        gettimeofday(&timestamp, NULL);
+
+        for (int i = 0; i < MAX_TRACE; i++) {
+            if (memory_trace[i].address == NULL) {
+                memory_trace[i].address = result;
                 memory_trace[i].size = size;
-                memory_trace[i].thread_id = syscall(__NR_gettid);
-                if (getenv("WPE_MEMCHECK_CALLSTACK")) {
-                    memory_trace_skip = 1;
+                memory_trace[i].tid = pthread_self();
+                memory_trace[i].timestamp = timestamp;
+                if (collect_callstack) {
                     memory_trace[i].call_stack_nb = backtrace(memory_trace[i].call_stack, MAX_CALLSTACK);
-                    memory_trace_skip = 0;
-                }
-                if (i >= memory_trace_max_cnt) {
-                    memory_trace_max_cnt = i + 1;
                 }
                 my_realloc_cnt++;
-                break;
+                goto done;
             }
         }
     }
+done:
     pthread_mutex_unlock(&memory_lock);
     return result;
 }
 
 void free(void* p) {
     static void (*libc_free)(void*) = NULL;
-    unsigned i;
-
     pthread_mutex_lock(&memory_lock);
     if (!libc_free) {
         libc_free = (void (*)(void*)) dlsym(RTLD_NEXT, "free");
     }
 
-    if (is_tmp_calloc(p)) {
-        pthread_mutex_unlock(&memory_lock);
-        return;
-    }
+    if(!p) goto exit;
+    if (is_tmp_calloc(p)) goto exit;
 
-    if (memory_trace_free_enabled) {
-        for (i = 0; i < memory_trace_max_cnt; i++) {
-            if (memory_trace[i].address == (void *) p) {
-                memory_trace[i].address = (void *) 0;
-                if ((i + 1) == memory_trace_max_cnt) {
-                    memory_trace_max_cnt--;
-                }
-                my_free_cnt++;
-                break;
-            }
+    if (!memory_trace_free_enabled) goto done;
+
+    for (int i = 0; i < MAX_TRACE; i++) {
+        if (memory_trace[i].address == p) {
+            free_total_size += memory_trace[i].size;
+            memory_trace[i].address = NULL;
+            my_free_cnt++;
+            goto done;
         }
     }
+done:
     libc_free(p);
+    ++free_total;
+exit:
     pthread_mutex_unlock(&memory_lock);
 }


### PR DESCRIPTION
Rename memcheck library for WPE 2.22 so the proper library is loaded
using ld preload mechanism:
- legacy wpe: memcheck
- wpe 2.22: memcheckthunder