### PR TITLE
ARRISEOS-41504: Disable some DRM-related logs

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMOpenCDM.cpp
@@ -653,7 +653,7 @@ String CDMInstanceOpenCDM::sessionIdByKeyId(const SharedBuffer& keyId) const
     if (result.isEmpty())
         GST_WARNING("Unknown session, nothing will be returned");
     else
-        GST_DEBUG("Found session for initdata: %s", result.utf8().data());
+        GST_LOG("Found session for initdata: %s", result.utf8().data());
 
     return result;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitOpenCDMDecryptorGStreamer.cpp
@@ -185,7 +185,7 @@ static SessionResult webKitMediaOpenCDMDecryptorResetSessionFromKeyIdIfNeeded(We
         GST_DEBUG_OBJECT(self, "new session %s is usable", session.utf8().data());
         returnValue = NewSession;
     } else {
-        GST_DEBUG_OBJECT(self, "same session %s", session.utf8().data());
+        GST_LOG_OBJECT(self, "same session %s", session.utf8().data());
         returnValue = OldSession;
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1395,7 +1395,7 @@ void AppendPipeline::handleProtectedBufferProbeInformation(GstPadProbeInfo* info
     if (!protectionMeta)
         return;
 
-    GST_DEBUG("adding %u protection events to buffer %p", listSize, buffer);
+    GST_LOG("adding %u protection events to buffer %p", listSize, buffer);
     gst_structure_set_value(protectionMeta->info, "stream-encryption-events", &m_cachedProtectionEvents);
 }
 


### PR DESCRIPTION
There's a lot of them, affecting performance, and they're not very useful.
To enable them, change gstdebug value to "webkit*:6" in WebKitBrowser.config