### PR TITLE
[ONEM-27195] Remove "missing plug-in" ODH report (#181)

### DIFF
--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -274,11 +274,6 @@ RefPtr<Widget> SubframeLoader::createJavaAppletWidget(const IntSize& size, HTMLA
     logPluginRequest(m_frame.page(), element.serviceType(), String(), widget);
 
     if (!widget) {
-        RenderEmbeddedObject* renderer = element.renderEmbeddedObject();
-
-        if (!renderer->isPluginUnavailable()) {
-            LOG_ERROR("Missing plug-in; Notification suppressed");
-        }
         return nullptr;
     }
 
@@ -426,8 +421,6 @@ bool SubframeLoader::loadPlugin(HTMLPlugInImageElement& pluginElement, const URL
         return false;
 
     if (!widget) {
-        if (!renderer->isPluginUnavailable())
-            LOG_ERROR("Missing plug-in; Notification suppressed");
         return false;
     }
 


### PR DESCRIPTION
This report indicated browser failed to load plugin with mechanism we
do not use. It has stubbed implementation and always returns error.
Such report doesn't provide any usefull information and only flooded kibana.