### PR TITLE
[ARRISEOS-42565] Fix uninitialized members and switch fallthrough

### DIFF
--- a/Source/WebKit/Platform/IPC/Attachment.h
+++ b/Source/WebKit/Platform/IPC/Attachment.h
@@ -93,7 +93,7 @@ private:
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     int m_fileDescriptor { -1 };
-    size_t m_size;
+    size_t m_size { };
 #elif OS(DARWIN)
     mach_port_name_t m_port;
     mach_msg_type_name_t m_disposition;

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -177,7 +177,7 @@ private:
     StringReference m_messageReceiverName;
     StringReference m_messageName;
 
-    uint64_t m_destinationID;
+    uint64_t m_destinationID { };
 
 #if PLATFORM(MAC)
     std::unique_ptr<ImportanceAssertion> m_importanceAssertion;

--- a/Source/WebKit/Platform/Module.h
+++ b/Source/WebKit/Platform/Module.h
@@ -77,7 +77,7 @@ private:
     CFBundleRefNum m_bundleResourceMap;
 #endif
 #elif USE(GLIB)
-    GModule* m_handle;
+    GModule* m_handle = nullptr;
 #endif
 };
 

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -46,7 +46,7 @@ struct LoadParameters {
     void platformEncode(IPC::Encoder&) const;
     static bool platformDecode(IPC::Decoder&, LoadParameters&);
 
-    uint64_t navigationID;
+    uint64_t navigationID { };
 
     WebCore::ResourceRequest request;
     SandboxExtension::Handle sandboxExtensionHandle;
@@ -59,7 +59,7 @@ struct LoadParameters {
     String unreachableURLString;
     String provisionalLoadErrorURLString;
 
-    uint64_t shouldOpenExternalURLsPolicy;
+    uint64_t shouldOpenExternalURLsPolicy { };
     bool shouldTreatAsContinuingLoad { false };
     UserData userData;
     bool forSafeBrowsing { false };

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -45,7 +45,7 @@ struct NavigationActionData {
     WebEvent::Modifiers modifiers { };
     WebMouseEvent::Button mouseButton { WebMouseEvent::NoButton };
     WebMouseEvent::SyntheticClickType syntheticClickType { WebMouseEvent::NoTap };
-    uint64_t userGestureTokenIdentifier;
+    uint64_t userGestureTokenIdentifier { };
     bool canHandleRequest { false };
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy { WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     WTF::String downloadAttribute;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -66,7 +66,7 @@ struct HTTPBody {
 
         // File.
         String filePath;
-        int64_t fileStart;
+        int64_t fileStart { };
         std::optional<int64_t> fileLength;
         std::optional<double> expectedFileModificationTime;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -755,8 +755,6 @@ static void pathEncodeApplierFunction(Encoder& encoder, const PathElement& eleme
 
     switch (element.type) {
     case PathElementMoveToPoint: // The points member will contain 1 value.
-        encoder << element.points[0];
-        break;
     case PathElementAddLineToPoint: // The points member will contain 1 value.
         encoder << element.points[0];
         break;

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -233,8 +233,8 @@ private:
     WebCore::IntPoint m_globalPosition;
     WebCore::FloatSize m_delta;
     WebCore::FloatSize m_wheelTicks;
-    uint32_t m_granularity; // Granularity
-    bool m_directionInvertedFromDevice;
+    uint32_t m_granularity { }; // Granularity
+    bool m_directionInvertedFromDevice { };
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     uint32_t m_phase { Phase::PhaseNone };
     uint32_t m_momentumPhase { Phase::PhaseNone };
@@ -303,9 +303,9 @@ private:
     String m_code;
 #endif
     String m_keyIdentifier;
-    int32_t m_windowsVirtualKeyCode;
-    int32_t m_nativeVirtualKeyCode;
-    int32_t m_macCharCode;
+    int32_t m_windowsVirtualKeyCode { };
+    int32_t m_nativeVirtualKeyCode { };
+    int32_t m_macCharCode { };
 #if USE(APPKIT) || PLATFORM(GTK)
     bool m_handledByInputMethod;
 #endif
@@ -314,9 +314,9 @@ private:
 #elif PLATFORM(GTK)
     Vector<String> m_commands;
 #endif
-    bool m_isAutoRepeat;
-    bool m_isKeypad;
-    bool m_isSystemKey;
+    bool m_isAutoRepeat { };
+    bool m_isKeypad { };
+    bool m_isSystemKey  { };
 };
 
 #if ENABLE(TOUCH_EVENTS)


### PR DESCRIPTION
All class embers should be initialized to prevent reading random values. Problem detected by static code analyser.