### PR TITLE
[ONEM-27901] hardcode segment time to 0 in AppendPipeline

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -110,7 +110,7 @@ static GstFlowReturn appendPipelineAppsinkNewSample(GstElement*, AppendPipeline*
 static void appendPipelineAppsinkEOS(GstElement*, AppendPipeline*);
 static void appendPipelineDemuxerNoMorePads(GstElement*, AppendPipeline*);
 
-static GstPadProbeReturn matroskademuxForceSegmentStartToEqualZero(GstPad*, GstPadProbeInfo*, void*);
+static GstPadProbeReturn demuxerForceSegmentStartToEqualZero(GstPad*, GstPadProbeInfo*, void*);
 
 static void appendPipelineNeedContextMessageCallback(GstBus*, GstMessage* message, AppendPipeline* appendPipeline)
 {
@@ -1196,9 +1196,7 @@ void AppendPipeline::connectDemuxerSrcPadToAppsink(GstPad* demuxerSrcPad)
     ASSERT(WTF::isMainThread());
     GST_DEBUG("Connecting to appsink");
 
-    const String& type = m_sourceBufferPrivate->type().containerType();
-    if (type.endsWith("webm"))
-        gst_pad_add_probe(demuxerSrcPad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, matroskademuxForceSegmentStartToEqualZero, nullptr, nullptr);
+    gst_pad_add_probe(demuxerSrcPad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, demuxerForceSegmentStartToEqualZero, nullptr, nullptr);
 
     LockHolder locker(m_padAddRemoveLock);
     GRefPtr<GstPad> sinkSinkPad = adoptGRef(gst_element_get_static_pad(m_appsink.get(), "sink"));
@@ -1482,7 +1480,7 @@ static void appendPipelineAppsinkEOS(GstElement*, AppendPipeline* appendPipeline
     GST_DEBUG("%s main thread", (WTF::isMainThread()) ? "Is" : "Not");
 }
 
-static GstPadProbeReturn matroskademuxForceSegmentStartToEqualZero(GstPad*, GstPadProbeInfo* info, void*)
+static GstPadProbeReturn demuxerForceSegmentStartToEqualZero(GstPad*, GstPadProbeInfo* info, void*)
 {
     // matroskademux sets GstSegment.start to the PTS of the first frame.
     //


### PR DESCRIPTION
On gstreamer 1.18.5 qtdemux sends new segment event upstream with segment start set to first pts from pushed data.
But when data from the past is pushed, it doesn't send new segment event at all. In normal pipeline it isn't big issue, because data from the past is pushed only during seek, and during seek qtdemux sends new segment event.

It's problematic in AppendPipeline, where we use demuxer as parser. We just push data into source and expect them to come out in sink.

With missing new segment event, appsink might have incorrect segment start and unnecesarly drop incomming buffers. In AppendPipeline we don't want that behaviour.

It seems there already was similar issue with matroska demux, so this commit just reuses that workaround.