### PR TITLE
[ARRISEOS-43048]: Fix SameSite cookie attribute presentation in Web Inspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Cookie.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Cookie.js
@@ -116,18 +116,19 @@ WI.Cookie = class Cookie
         }
     }
 
-    // Derived from <https://tools.ietf.org/html/draft-west-first-party-cookies-06#section-3.2>.
     static parseSameSiteAttributeValue(attributeValue)
     {
         if (!attributeValue)
-            return WI.Cookie.SameSiteType.Strict;
+            return WI.Cookie.SameSiteType.None;
+
         switch (attributeValue.toLowerCase()) {
         case "lax":
             return WI.Cookie.SameSiteType.Lax;
         case "strict":
-        default:
             return WI.Cookie.SameSiteType.Strict;
         }
+
+        return WI.Cookie.SameSiteType.None;
     }
 
     static parseSetCookieResponseHeader(header)


### PR DESCRIPTION
In Web Inspector, in Network tab SameSite attribute is shown as Strict even when attribute was set to None. This issue is causing misleading among web developers:

![network_tab](https://user-images.githubusercontent.com/42027818/196234158-dd3bb545-478c-4b42-b219-e7fd16e1693f.png)

On other Web Inspector tabs (Resources, Storage) SameSite attribute has correct value:
![resources_tab](https://user-images.githubusercontent.com/42027818/196234272-935f572b-df81-4c49-9928-05b361cb5b39.png)
![storage_tab](https://user-images.githubusercontent.com/42027818/196234307-a8c2c5c9-9ca0-4b79-861d-1a7a90b4a18d.png)

Fix is based on upstream PR (which is present in WPE2.28):
https://github.com/WebKit/WebKit/commit/644049b6feb

