### PR TITLE
[ARRISEOS-43048]: Fix SameSite attribute presentation in Web Inspector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Cookie.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Cookie.js
@@ -116,18 +116,19 @@ WI.Cookie = class Cookie
         }
     }
 
-    // Derived from <https://tools.ietf.org/html/draft-west-first-party-cookies-06#section-3.2>.
     static parseSameSiteAttributeValue(attributeValue)
     {
         if (!attributeValue)
-            return WI.Cookie.SameSiteType.Strict;
+            return WI.Cookie.SameSiteType.None;
+
         switch (attributeValue.toLowerCase()) {
         case "lax":
             return WI.Cookie.SameSiteType.Lax;
         case "strict":
-        default:
             return WI.Cookie.SameSiteType.Strict;
         }
+
+        return WI.Cookie.SameSiteType.None;
     }
 
     static parseSetCookieResponseHeader(header)


### PR DESCRIPTION
In Web Inspector, in Network tab SameSite attribute is shown as Strict even when attribute was set to None.

Fix is based on upstream PR:
https://github.com/WebKit/WebKit/commit/644049b6feb