### PR TITLE
[ONEM-28251] Improve ODH error reporting

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -224,8 +224,8 @@ WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 WTF_EXPORT_PRIVATE void WTFGetBacktrace(void** stack, int* size);
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 WTF_EXPORT_PRIVATE void WTFPrintBacktrace(void** stack, int size);
-WTF_EXPORT_PRIVATE void WTFReportOdhError(const char* format, ...);
-WTF_EXPORT_PRIVATE void WTFReportOdhErrorV(const char* format, va_list args);
+WTF_EXPORT_PRIVATE void WTFReportOdhError(const char* file, int line, const char* function, const char* format, ...);
+WTF_EXPORT_PRIVATE void WTFReportOdhErrorV(const char* file, int line, const char* function, const char* format, va_list args);
 #if !RELEASE_LOG_DISABLED
 WTF_EXPORT_PRIVATE void WTFReleaseLogStackTrace(WTFLogChannel*);
 #endif
@@ -486,7 +486,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 #define LOG_ERROR(...) do { \
     RDK_LOG_VERBOSE(RDK_LOG_ERROR, RDK_LOG_DEFAULT_CHANNEL); \
     RDK_LOG(RDK_LOG_ERROR, RDK_LOG_DEFAULT_CHANNEL, __VA_ARGS__); \
-    WTFReportOdhError(__VA_ARGS__); \
+    WTFReportOdhError(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, __VA_ARGS__); \
 } while (0)
 #else
 #define LOG_ERROR(...) WTFReportError(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, __VA_ARGS__)

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
@@ -29,15 +29,23 @@
 
 #include "ChildProcessMain.h"
 #include "NetworkProcessMainUnix.h"
+#include <rdk/libodherr/odherr.h>
 #include <WebCore/NetworkStorageSession.h>
 
 namespace WebKit {
 
 class NetworkProcessMain final: public ChildProcessMainBase {
 public:
+    bool platformInitialize() override
+    {
+        odh_error_report_init("WebKitBrowser");
+        return true;
+    }
+
     void platformFinalize() override
     {
         WebCore::NetworkStorageSession::defaultStorageSession().clearSoupNetworkSessionAndCookieStorage();
+        odh_error_report_deinit(ODH_ERROR_REPORT_DEINIT_MODE_DEFERRED);
     }
 };
 

--- a/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
+++ b/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
@@ -33,6 +33,7 @@
 #include <glib.h>
 #include <iostream>
 #include <libsoup/soup.h>
+#include <rdk/libodherr/odherr.h>
 #include <wpe/wpe.h>
 
 namespace WebKit {
@@ -50,6 +51,8 @@ public:
         // Required for GStreamer initialization.
         // FIXME: This should be probably called in other processes as well.
         g_set_prgname("WPEWebProcess");
+
+        odh_error_report_init("WebKitBrowser");
 
         return true;
     }
@@ -74,6 +77,11 @@ public:
                 downcast<PlatformDisplayWPE>(PlatformDisplay::sharedDisplay()).initialize(wpeFd);
             });
         return true;
+    }
+
+    void platformFinalize() override
+    {
+        odh_error_report_deinit(ODH_ERROR_REPORT_DEINIT_MODE_DEFERRED);
     }
 };
 


### PR DESCRIPTION
Example report:

ErrorReport.backtrace
    /usr/src/debug/wpe-webkit/.../MediaPlayerPrivateGStreamer.cpp:232
    WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(WebCore::MediaPlayer*)
ErrorReport.category
    browser
ErrorReport.code
    WPE0050
ErrorReport.ctx.wpe.file
    /usr/src/debug/wpe-webkit/.../MediaPlayerPrivateGStreamer.cpp
ErrorReport.ctx.wpe.function
    WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(WebCore::MediaPlayer*)
ErrorReport.errmsg
    This is an error message
ErrorReport.level
    ERROR
ErrorReport.source
    WebKitBrowser