### PR TITLE
[ARRISEOS-43118]: Reduce gstqueue2 size for shoutcast streams

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1769,25 +1769,11 @@ void MediaPlayerPrivateGStreamer::tryReduceQueueSize(GstObject* queue)
 {
     guint max_size_bytes = 0;
     g_object_get(queue, "max-size-bytes", &max_size_bytes, NULL);
-    bool update_queue_size = true;
-
-#if GST_CHECK_VERSION(1, 16, 0) // bitrate query is available from version 1.16
-    GstQuery* query = gst_query_new_bitrate();
-    if (gst_element_query(m_pipeline.get(), query.get())) {
-        guint bitrate = 0;
-        gst_query_parse_bitrate(query, &bitrate);
-        GST_DEBUG("Stream bitrate value: %u\n", bitrate);
-        if (bitrate) {
-            update_queue_size = false;
-        }
-    }
-    gst_query_unref(query);
-#endif
 
     // ARRISEOS-43118 : for some specific aac shoutcast streams mpegaudioparse plugin is not attached to pipeline and in consequence bitstream
     // value cannot be correctly calculated. UriDecodeBin is setting queue size based on that bitstream value.
     // Let's reduce for those specific audio streams queue size to reasonable size
-    if (update_queue_size && max_size_bytes >= 2097152) {
+    if (max_size_bytes >= 2097152) {
          GST_DEBUG("Hardcode queue max size\n");
          g_object_set(queue, "max-size-bytes", 16000, NULL);
     }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -377,6 +377,8 @@ void MediaPlayerPrivateGStreamer::loadFull(const String& urlString, const gchar*
     m_volumeAndMuteInitialized = false;
     m_durationAtEOS = MediaTime::invalidTime();
 
+    m_isShoutcastStreaming = false;
+
     if (!m_delayingLoad)
         commitLoad();
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1422,6 +1422,9 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
 #endif
 
 #if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
+        if (currentState == GST_STATE_NULL && newState == GST_STATE_READY && g_strstr_len(GST_MESSAGE_SRC_NAME(message), 8, "icydemux")) {
+            m_isShoutcastStreaming = true;
+        }
         if (currentState == GST_STATE_NULL && newState == GST_STATE_READY && g_strstr_len(GST_MESSAGE_SRC_NAME(message), 13, "brcmvidfilter")) {
             m_vidfilter = GST_ELEMENT(GST_MESSAGE_SRC(message));
 
@@ -1688,6 +1691,8 @@ void MediaPlayerPrivateGStreamer::processBufferingStats(GstMessage* message)
 
     m_buffering = true;
     gst_message_parse_buffering(message, &m_bufferingPercentage);
+    GST_LOG("Buffering percentage: %d", m_bufferingPercentage);
+    GstObject* queue2 = GST_MESSAGE_SRC(message);
 
 #if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
     // The Nexus playpump buffers a lot of data. Let's add it as if it had been buffered by the GstQueue2
@@ -1699,8 +1704,6 @@ void MediaPlayerPrivateGStreamer::processBufferingStats(GstMessage* message)
 
         int updatedBufferingPercentage = m_bufferingPercentage;
         int correctedBufferingPercentage = m_bufferingPercentage;
-
-        GstObject *queue2 = GST_MESSAGE_SRC(message);
         guint maxSizeBytes = 0;
 
         // Current-level-bytes seems to be inacurate, so we compute its value from the buffering percentage.
@@ -1749,14 +1752,44 @@ void MediaPlayerPrivateGStreamer::processBufferingStats(GstMessage* message)
         }
     } else
 #endif
-
-    GST_TRACE("[Buffering] max loaded time: %s, current playback position: %s",
-              toString(m_maxTimeLoaded).utf8().data(),
-              toString(playbackPosition()).utf8().data());
+        GST_TRACE("[Buffering] max loaded time: %s, current playback position: %s",
+                  toString(m_maxTimeLoaded).utf8().data(),
+                  toString(playbackPosition()).utf8().data());
+    if (m_isShoutcastStreaming) {
+        tryReduceQueueSize(queue2);
+    }
 
     if (m_bufferingPercentage == 100 ||
             (m_bufferingPercentage == 0 && (m_maxTimeLoaded - playbackPosition() < MediaTime::createWithDouble(2, GST_SECOND)))) {
         updateStates();
+    }
+}
+
+void MediaPlayerPrivateGStreamer::tryReduceQueueSize(GstObject* queue)
+{
+    guint max_size_bytes = 0;
+    g_object_get(queue, "max-size-bytes", &max_size_bytes, NULL);
+    bool update_queue_size = true;
+
+#if GST_CHECK_VERSION(1, 16, 0) // bitrate query is available from version 1.16
+    GstQuery* query = gst_query_new_bitrate();
+    if (gst_element_query(m_pipeline.get(), query.get())) {
+        guint bitrate = 0;
+        gst_query_parse_bitrate(query, &bitrate);
+        GST_DEBUG("Stream bitrate value: %u\n", bitrate);
+        if (bitrate) {
+            update_queue_size = false;
+        }
+    }
+    gst_query_unref(query);
+#endif
+
+    // ARRISEOS-43118 : for some specific aac shoutcast streams mpegaudioparse plugin is not attached to pipeline and in consequence bitstream
+    // value cannot be correctly calculated. UriDecodeBin is setting queue size based on that bitstream value.
+    // Let's reduce for those specific audio streams queue size to reasonable size
+    if (update_queue_size && max_size_bytes >= 2097152) {
+         GST_DEBUG("Hardcode queue max size\n");
+         g_object_set(queue, "max-size-bytes", 16000, NULL);
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -210,6 +210,7 @@ private:
     long long determineTotalBytes() const;
 
     void updateFrameStats() const;
+    void tryReduceQueueSize(GstObject* queue);
 
 protected:
     bool m_buffering;
@@ -336,6 +337,7 @@ private:
 #if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
     GRefPtr<GstElement> m_vidfilter;
     GRefPtr<GstElement> m_multiqueue;
+    bool m_isShoutcastStreaming = false;
 #endif
 
     DemuxMonitor _demuxMonitor;


### PR DESCRIPTION
For some specific AAC shoutcast streams (Sampling Rate: 21.533, Samples Per Frame: 2048) MpegAudioParse plugin is not attached to pipeline and in consequence bitstream value cannot be correctly calculated. UriDecodeBin is setting queue size based on that bitstream value. Let's reduce for those specific audio streams queue size to reasonable size.

Fix is continuation of https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/957/
Fix is not related to Comcast not upstreamable solution: https://github.com/rdkcmf/meta-rdk-ext/blob/rdk-next/recipes-extended/wpe-webkit/files/0051-comcast-Internet-Audio-live-streaming-issues-fixed_0.4.patch

Regression risk only is related to shutcast streaming (present in apps: radio paradise, radioline).

Issue is not reproducing on RPI, so this PR is not upstreamable. 