### PR TITLE
[ARRISEOS-43118]: Reduce gstqueue2 size for shoutcast streams (#204)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -210,6 +210,7 @@ private:
     long long determineTotalBytes() const;
 
     void updateFrameStats() const;
+    void tryReduceQueueSize(GstObject* queue);
 
 protected:
     bool m_buffering;
@@ -336,6 +337,7 @@ private:
 #if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
     GRefPtr<GstElement> m_vidfilter;
     GRefPtr<GstElement> m_multiqueue;
+    bool m_isShoutcastStreaming = false;
 #endif
 
     DemuxMonitor _demuxMonitor;


### PR DESCRIPTION
* [ARRISEOS-43118]: Reduce gstqueue2 size for shoutcast streams

For some specific AAC shoutcast streams MpegAudioParse plugin is not attached to pipeline and in consequence bitstream value cannot be correctly calculated. UriDecodeBin is setting queue size based on that bitstream value. Let's reduce for those specific audio streams queue size to reasonable size.

Co-authored-by: Jacek Skiba <jacek.skiba@consult.red>