### PR TITLE
[HUMAXEOS-4861] Unregister callbacks when gst element is removed (#215)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DemuxMonitor.h
+++ b/Source/WebCore/platform/graphics/gstreamer/DemuxMonitor.h
@@ -19,13 +19,14 @@ private:
     GstPadProbeReturn onPadProbeBuffer(GstPad* pad, GstBuffer* buffer);
 
     static void onElementAddedCb(GstBin *pipeline, GstElement *element, gpointer data);
+    static void onElementRemovedCb(GstBin *pipeline, GstElement *element, gpointer data);
     static void onPadAddedCb(GstElement* element, GstPad* newPad, gpointer data);
     static GstPadProbeReturn onPadProbeCb(GstPad* pad, GstPadProbeInfo* info, gpointer data);
 
-    const uint64_t                SKIP_TRESHOLD{200*GST_MSECOND};
-    uint64_t                      m_seekTimestamp{0};
-    bool                          m_skipFirst{false};
-    std::map<GstElement*, gulong> m_handlerIds{};
+    const uint64_t                          SKIP_TRESHOLD{200*GST_MSECOND};
+    uint64_t                                m_seekTimestamp{0};
+    bool                                    m_skipFirst{false};
+    std::multimap<GstElement*, gulong>      m_handlerIds{};
 };
 
 }


### PR DESCRIPTION
When DemuxMonitor destructor is executed it unregisters glib signals for gst elements which can be already freed.
Monitor gstreamer elements removal by handling "element-removed" signal which unregisters callbacks for given element and removes gst element from the multimap.