### PR TITLE
[ONEM-27424] Fix core dump when aborting MSE pipeline

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -433,7 +433,8 @@ MediaTime SourceBuffer::highestPresentationTimestamp() const
 
 void SourceBuffer::readyStateChanged()
 {
-    updateBufferedFromTrackBuffers();
+    if (!isRemoved())
+        updateBufferedFromTrackBuffers();
 }
 
 void SourceBuffer::removedFromMediaSource()
@@ -1582,7 +1583,7 @@ void SourceBuffer::appendError(bool decodeErrorParam)
     scheduleEvent(eventNames().updateendEvent);
 
     // 5. If decode error is true, then run the end of stream algorithm with the error parameter set to "decode".
-    if (decodeErrorParam)
+    if (decodeErrorParam && !isRemoved())
         m_source->streamEndedWithError(MediaSource::EndOfStreamError::Decode);
 }
 


### PR DESCRIPTION
Fix use after free vulnerability when MediaSource uses already freed SourceBuffer.
This patch is based on upstream fix:
https://github.com/WebKit/WebKit/commit/9377801dd77517bee60becbb1ed328b3b3ad8f30