### PR TITLE
[ONEM-22658] WebCrypto API is available only in secure context (https)

### DIFF
--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -152,6 +152,7 @@ namespace WebCore {
     macro(ShadowRoot) \
     macro(SpectreGadget) \
     macro(StaticRange) \
+    macro(SubtleCrypto) \
     macro(VRDisplay) \
     macro(VRDisplayCapabilities) \
     macro(VRDisplayEvent) \

--- a/Source/WebCore/crypto/SubtleCrypto.idl
+++ b/Source/WebCore/crypto/SubtleCrypto.idl
@@ -29,6 +29,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
 
 [
     Conditional=SUBTLE_CRYPTO,
+    SecureContext,
     Exposed=(Window,Worker),
     GenerateIsReachable=ImplScriptExecutionContext,
 ] interface SubtleCrypto {

--- a/Source/WebCore/page/Crypto.idl
+++ b/Source/WebCore/page/Crypto.idl
@@ -31,6 +31,6 @@
     Exposed=(Window,Worker),
     GenerateIsReachable=ImplScriptExecutionContext,
 ] interface Crypto {
-    [Conditional=SUBTLE_CRYPTO] readonly attribute SubtleCrypto subtle;
+    [Conditional=SUBTLE_CRYPTO, SecureContext] readonly attribute SubtleCrypto subtle;
     [MayThrowException] ArrayBufferView getRandomValues([ReturnValue] ArrayBufferView array);
 };


### PR DESCRIPTION
Backport of https://bugs.webkit.org/attachment.cgi?id=312799&action=diff