### PR TITLE
[ARRISEOS-43568]: AppleTV - fix trickplay during rewind

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1328,6 +1328,10 @@ void AppendPipeline::disconnectDemuxerSrcPadFromAppsinkFromAnyThread(GstPad* dem
             GST_DEBUG("The remaining compatible pad has a blackHoleProbe, reconnecting as main pad. oldPad: %" GST_PTR_FORMAT ", newPad: %" GST_PTR_FORMAT ", peerPad: %" GST_PTR_FORMAT, demuxerSrcPad, remainingPad, oldPeerPad.get());
 
             gst_pad_link(remainingPad, oldPeerPad.get());
+
+            // after pad relinkage attach the same probe which updates gstsegment
+            gst_pad_add_probe(remainingPad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, demuxerForceSegmentStartToEqualZero, nullptr, nullptr);
+
             if (m_parser)
                 gst_element_set_state(m_parser.get(), GST_STATE_NULL);
             gst_element_set_state(m_appsink.get(), GST_STATE_NULL);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1318,9 +1318,8 @@ void AppendPipeline::disconnectDemuxerSrcPadFromAppsinkFromAnyThread(GstPad* dem
         }
     }
     if (remainingPad) {
-
         auto probeId = GPOINTER_TO_ULONG(g_object_get_data(G_OBJECT(remainingPad), "blackHoleProbeId"));
-        if (remainingPad && probeId) {
+        if (probeId) {
             gst_pad_remove_probe(remainingPad, probeId);
 
             // FIXME: Unlike in upstream (2020-09-10), demuxerSrcPad and oldPeerPad always have null caps at this point, so it doesn't


### PR DESCRIPTION
[ARRISEOS-43568]: AppleTV - fix trickplay during rewind

During trickplay pads between demux and appsink elements are relinked:
- new pads on demux element are added via pad-added signal
- old pads from demux element are removed via pad-removed signal
- pad relinkage happends between demux and appsink element

After pad relinkage probe which was updating GstSegment start position is not
reconnected. This is causing errors during trickmode playback: gst buffers
related to trick playback are rejected/clipped by appsink (more precisely, by its base
class: gstbasesink), because gstsegment start position value don't match to those
gst buffers.