### PR TITLE
[ARRISEOS-43753]: Apple TV - remove flow which generates GStreamer-CRITICAL

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1266,7 +1266,16 @@ void AppendPipeline::disconnectDemuxerSrcPadFromAppsinkFromAnyThread(GstPad* dem
         return padCaps ? capsMediaType(padCaps.get()) : nullptr;
     };
 
+    auto isAudioOrVideo = [](const std::string& padType) {
+        if (!padType.compare(0, 5, "audio") || !padType.compare(0, 5, "video"))
+            return true;
+        return false;
+    };
+
     const char* demuxerSrcPadType = getPadType(demuxerSrcPad);
+    if (demuxerSrcPadType && !isAudioOrVideo(demuxerSrcPadType)) {
+        return;
+    }
 
     auto oldPeerPad = adoptGRef(gst_element_get_static_pad(m_appsink.get(), "sink"));
     while (gst_pad_is_linked(oldPeerPad.get())) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1267,9 +1267,7 @@ void AppendPipeline::disconnectDemuxerSrcPadFromAppsinkFromAnyThread(GstPad* dem
     };
 
     auto isAudioOrVideo = [](const std::string& padType) {
-        if (!padType.compare(0, 5, "audio") || !padType.compare(0, 5, "video"))
-            return true;
-        return false;
+        return !padType.compare(0, 5, "audio") || !padType.compare(0, 5, "video");
     };
 
     const char* demuxerSrcPadType = getPadType(demuxerSrcPad);


### PR DESCRIPTION
In Apple TV video stream we have multiplexed closed caption content which is recognized by qtdemux plugin (x-cea-608 sink pad is created).

During trickplay pads between demux and appsink elements are relinked:
- new video pad on demux element is added via pad-added signal (connected to probe)
- old video pad from demux element is removed via pad-removed signal
- video pad relinkage happends
- x-cea-608 pad from demux element is removed via pad-removed signal

At this point AppendPipeline is linked, and while loop which starts from appsink iterates to appsrc, and looks for appsrc sink pad, which generates GStreamer-CRITICAL error.