### PR TITLE
[ARRISEOS-43508]: Drop float precision in surface comparison

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -885,17 +885,15 @@ void drawSurface(PlatformContextCairo& platformContext, cairo_surface_t* surface
     RefPtr<cairo_surface_t> patternSurface = surface;
     float leftPadding = 0;
     float topPadding = 0;
-    if (srcRect.x() || srcRect.y() || srcRect.size() != cairoSurfaceSize(surface)) {
-        // Cairo subsurfaces don't support floating point boundaries well, so we expand the rectangle.
-        IntRect expandedSrcRect(enclosingIntRect(srcRect));
-
+    IntRect srcRectIntSize = IntRect(srcRect);
+    if (srcRect.x() || srcRect.y() || srcRectIntSize.size() != cairoSurfaceSize(surface)) {
         // We use a subsurface here so that we don't end up sampling outside the originalSrcRect rectangle.
         // See https://bugs.webkit.org/show_bug.cgi?id=58309
-        patternSurface = adoptRef(cairo_surface_create_for_rectangle(surface, expandedSrcRect.x(),
-            expandedSrcRect.y(), expandedSrcRect.width(), expandedSrcRect.height()));
+        patternSurface = adoptRef(cairo_surface_create_for_rectangle(surface, srcRectIntSize.x(),
+            srcRectIntSize.y(), srcRectIntSize.width(), srcRectIntSize.height()));
 
-        leftPadding = static_cast<float>(expandedSrcRect.x()) - floorf(srcRect.x());
-        topPadding = static_cast<float>(expandedSrcRect.y()) - floorf(srcRect.y());
+        leftPadding = static_cast<float>(srcRectIntSize.x()) - floorf(srcRect.x());
+        topPadding = static_cast<float>(srcRectIntSize.y()) - floorf(srcRect.y());
     }
 
     RefPtr<cairo_pattern_t> pattern = adoptRef(cairo_pattern_create_for_surface(patternSurface.get()));


### PR DESCRIPTION
This commit fixes a crash that was encountered in Pixman. The crash was caused by a subsurface that is bigger than the surface, so we end up reading not allocated memory.
In the committed code, we change FloatRect type to IntRect. Thanks to this we prevent of IntRect promotion to FloatRect from cairoSurfaceSize, so with the fix we compare int size not floats. Float comparisons are untrustworthy.
In a crash scenario the code state that 480.000031 is not equal to 480 and we have to create a subsurface.
enclosingIntRect method used ceil method to set width, and height, because of this 480.000031 becomes 481 which is bigger than the original surface.