### PR TITLE
[ARRISEOS-43508] Image::drawTiled → Cairo::drawSurface → cairo_paint_…

### DIFF
--- a/Source/WebCore/ChangeLog
+++ b/Source/WebCore/ChangeLog
@@ -14,6 +14,24 @@
         * testing/Internals.h:
         * testing/Internals.idl:
 
+2019-09-16  Fujii Hironori  <Hironori.Fujii@sony.com>
+
+        [Cairo] Image::drawTiled → Cairo::drawSurface → cairo_paint_with_alpha → segfault happens in pixman
+        https://bugs.webkit.org/show_bug.cgi?id=201755
+
+        Reviewed by Don Olmstead.
+
+        Segmentation faults happened in pixman while painting a image. In
+        Cairo::drawSurface, originalSrcRect can be slightly larger than
+        the surface size because of floating number calculations.
+        Cairo::drawSurface created a subsurface which is running over the
+        parent surface boundaries.
+
+        * platform/graphics/cairo/CairoOperations.cpp:
+        (WebCore::Cairo::drawSurface): Calculated a intersection with
+        expandedSrcRect and the parent surface size for subsurface size.
+
+
 2019-07-05  Youenn Fablet  <youenn@apple.com> and Simon Fraser  <simon.fraser@apple.com>
 
         Trigger a compositing update when video element is changing

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -888,6 +888,7 @@ void drawSurface(PlatformContextCairo& platformContext, cairo_surface_t* surface
     if (srcRect.x() || srcRect.y() || srcRect.size() != cairoSurfaceSize(surface)) {
         // Cairo subsurfaces don't support floating point boundaries well, so we expand the rectangle.
         IntRect expandedSrcRect(enclosingIntRect(srcRect));
+        expandedSrcRect.intersect({ { }, cairoSurfaceSize(surface) });
 
         // We use a subsurface here so that we don't end up sampling outside the originalSrcRect rectangle.
         // See https://bugs.webkit.org/show_bug.cgi?id=58309


### PR DESCRIPTION
…with_alpha → segfault happens in pixman

https://bugs.webkit.org/show_bug.cgi?id=201755

Reviewed by Don Olmstead.

Segmentation faults happened in pixman while painting a image. In Cairo::drawSurface, originalSrcRect can be slightly larger than the surface size because of floating number calculations. Cairo::drawSurface created a subsurface which is running over the parent surface boundaries.

* platform/graphics/cairo/CairoOperations.cpp: (WebCore::Cairo::drawSurface): Calculated a intersection with expandedSrcRect and the parent surface size for subsurface size.

git-svn-id: http://svn.webkit.org/repository/webkit/trunk@249937 268f45cc-cd09-0410-ab3c-d52691b4dbfc