### PR TITLE
[ARRISEOS-43855]: Update OneSDK URL whitelisting rules

### DIFF
--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -40,29 +40,9 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
-#include <sstream>
-#include <vector>
-
 namespace WebCore {
 
 namespace {
-
-bool isUrlWhitelisted(const URL &url) {
-    static std::vector<URL> whitelisted_urls;
-    if (whitelisted_urls.empty() && getenv("WPE_MIXEDCONTENT_WHITELIST")) {
-        std::stringstream wl_env(getenv("WPE_MIXEDCONTENT_WHITELIST"));
-        std::string wl_item;
-        while (std::getline(wl_env, wl_item, ',')) {
-            URL wl_url(URL(), wl_item.c_str());
-            whitelisted_urls.push_back(wl_url);
-        }
-    }
-
-    for (auto &wl_url : whitelisted_urls) {
-        if (protocolHostAndPortAreEqual(wl_url, url)) return true;
-    }
-    return false;
-}
 
 } // namespace
 
@@ -119,9 +99,6 @@ bool MixedContentChecker::canRunInsecureContent(SecurityOrigin& securityOrigin, 
         return false;
 
     bool allowed = !m_frame.document()->isStrictMixedContentMode() && m_frame.settings().allowRunningOfInsecureContent() && !m_frame.document()->geolocationAccessed() && !m_frame.document()->secureCookiesAccessed();
-
-    // When mixed content is enabled check if URL is whitelisted
-    if (!allowed && isUrlWhitelisted(url)) return true;
 
     if (!allowed)
         logWarning(allowed, "run", url);


### PR DESCRIPTION
This fix contains two parts:
1. Do whitelisting comparison only for WebSockets; OneSDK is using not secure WS WebSockets to communicate with UI and AppServices

2. We are doing whitelistng check for pages independently if mixed-content is enabled for them:
- BBC IPlayer / BBC Sounds has mixed-content disabled
- Apple TV has mix-content enabled 
All above applications are using secure cookies, and those coookies cannot be blocked by WPE.