### PR TITLE
ARRISEOS-43540: Missing support for aborts not followed by an initialization segment

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -925,8 +925,10 @@ void AppendPipeline::resetPipeline()
     ASSERT(WTF::isMainThread());
     GST_DEBUG("resetting pipeline");
 
-    gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
-    gst_element_get_state(m_pipeline.get(), nullptr, nullptr, 0);
+    // gst_element_send_event(m_appsrc.get(), gst_event_new_flush_start());
+    // gst_element_send_event(m_appsrc.get(), gst_event_new_flush_stop(true));
+
+    gst_element_seek(m_pipeline.get(), 1.0, GST_FORMAT_BYTES, GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET, 0, GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
 
 #if (!(LOG_DISABLED || defined(GST_DISABLE_GST_DEBUG)))
     {


### PR DESCRIPTION
abort

[MSE][GStreamer] Missing support for aborts not followed by an initia… …lization segment

https://bugs.webkit.org/show_bug.cgi?id=228820

This patch performs a flushing seek to 0 on the AppendPipeline on SourceBuffer::abort(). Such action creates internal flush events that drain the AppendPipeline but leave the demuxer still configured with the context provided by the last init segment. This is in compliance with the spec, which mandates that there's no need to append an init segment after an abort, because the last one should be reused.

At first, I tried to achieve this by directly sending flush-start, flush-stop and segment events to appsrc, but got a not easily solvable crash in qtdemux. Doing a seek achieves the same effect in practical terms without problems.

This patch still does NOT pass the layout tests:

media/media-source/media-mp4-h264-partial-abort.html media/media-source/media-webm-opus-partial-abort.html

The reason is that the layout tests append partial data on purpose to check how the demuxer recovers from that, and qtdemux can't yet recover from that situation. However, if the tests are modified to use append full fragments, the test passes. Still, this patch would be an improvement and would unblock the test case in

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::resetParserState): Perform a seek instead of setting the pipeline state to READY and then again to PLAYING.