### PR TITLE
[HUMAXEOS-4885]: Fix artifacts on STV at the end of the movie

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -255,6 +255,12 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
     gst_base_sink_set_sync(GST_BASE_SINK(m_appsink.get()), FALSE);
     gst_base_sink_set_last_sample_enabled(GST_BASE_SINK(m_appsink.get()), FALSE);
 
+    bool disableClipping = getenv("DISABLE_CLIPPING") != nullptr && *getenv("DISABLE_CLIPPING") == '1';
+    if (disableClipping) {
+        GST_DEBUG("Disabling clipping basesink feature");
+        gst_base_sink_set_drop_out_of_segment(GST_BASE_SINK(m_appsink.get()), FALSE);
+    }
+
     GRefPtr<GstPad> appsinkPad = adoptGRef(gst_element_get_static_pad(m_appsink.get(), "sink"));
     g_signal_connect(appsinkPad.get(), "notify::caps", G_CALLBACK(appendPipelineAppsinkCapsChanged), this);
 


### PR DESCRIPTION
Configure sink to not drop buffers which are outside the current segment. This way we do not lost video frames which are valid.

Example of currently dropped buffer:
- gst segment stop time: 1:30:00.00
- gst buffer dts: 1:29:59.80, pts: 1:30:00.04
Currently buffer is dropped because pts (1:30:00.04) is higher then gst stop time (1:30:00.00).

This condition is too strict for STV content. We don't see also that strict requirement in Dash specification. 

