### PR TITLE
[ARRISEOS-43803]: Disable unsupported resolutions for h264

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -88,6 +88,7 @@ public:
 
     static bool supportsCodec(String codec);
     static bool supportsAllCodecs(const Vector<String>& codecs);
+    static bool isAnyCodecH264AndExceedSupportedSize(const Vector<String>& codecs, float width, float height);
 
 #if ENABLE(ENCRYPTED_MEDIA)
     void dispatchDecryptionStructure(GUniquePtr<GstStructure>&&) final;

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -178,6 +178,18 @@ if (ENABLE_CBCS)
     add_definitions(-DENABLE_CBCS=1)
 endif()
 
+if (PLATFORM_EOS)
+    add_definitions(-DWTF_PLATFORM_EOS=1)
+endif()
+
+if (PLATFORM_EOS2008C)
+    add_definitions(-DWTF_PLATFORM_EOS2008C=1)
+endif()
+
+if (PLATFORM_APOLLO)
+    add_definitions(-DWTF_PLATFORM_APOLLO=1)
+endif()
+
 add_definitions(-DBUILDING_WPE__=1)
 add_definitions(-DGETTEXT_PACKAGE="WPE")
 add_definitions(-DJSC_GLIB_API_ENABLED)


### PR DESCRIPTION
This commit disables unsupported h264 resolutions for eos and eos2008c devices.

DEPS=meta-lgi-eos:106588/1
DEPS=meta-lgi-wpe:106590/1
DEPS=meta-lgi-eos2008c:106591/1