### PR TITLE
[ARRISEOS-43921] Make MSE pipeline finishing in PAUSED state (#267)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2698,7 +2698,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
 
     m_isEndReached = true;
 
-    if (!m_player->client().mediaPlayerIsLooping()) {
+    if (!m_player->client().mediaPlayerIsLooping() && !isMediaSource()) {
         timeChanged();
         m_paused = true;
         m_durationAtEOS = durationMediaTime();


### PR DESCRIPTION
This commit just cherry-picks one line from:
https://github.com/WebKit/WebKit/commit/9382c6ef1a5b64d1701c691c63fe84de22cf932b so that MSE pipeline finishes in PAUSED state (instead of READY) so that media player keeps displaying last video frame after playback ends.