### PR TITLE
ONEM-30717: Send close notification on window.close()

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1073,8 +1073,10 @@ void DOMWindow::close()
     if (!frame->isMainFrame())
         return;
 
-    if (!(page->openedByDOM() || page->backForward().count() <= 1 || frame->settings().allowScriptsToCloseWindows())) {
-        console()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
+    // Make allowScriptsToCloseWindow pref value take precedence when closing window
+    if (!frame->settings().allowScriptsToCloseWindows() || !(page->openedByDOM() || page->backForward().count() <= 1)) {
+        // Send close notification to give a chance for AWC to react on window.close()
+        page->chrome().closeWindow();
         return;
     }
 


### PR DESCRIPTION
Send close notification even when 'allowScriptsToCloseWindow' preference is not set.
This patch is based on following legacy changes:
* LibertyGlobal/wpe-webkit@1bf6ab0
* 0158.window_close.patch