### PR TITLE
ONEM-30618: Use static port for internal webinspector communication

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
@@ -75,8 +75,15 @@ static void initializeRemoteInspectorServer()
 
     auto inspectorHTTPAddress = parseAddress(httpAddress);
     GRefPtr<GSocketAddress> inspectorAddress;
-    if (inspectorHTTPAddress)
-        inspectorAddress = adoptGRef(G_SOCKET_ADDRESS(g_inet_socket_address_new(g_inet_socket_address_get_address(G_INET_SOCKET_ADDRESS(inspectorHTTPAddress.get())), 0)));
+    if (inspectorHTTPAddress) {
+        const char* inspectorPortStr = g_getenv("WEBKIT_INSPECTOR_PORT");
+        auto port = inspectorPortStr ? g_ascii_strtoull(inspectorPortStr, nullptr, 10) : 0;
+        if (port > std::numeric_limits<uint16_t>::max()) {
+            g_warning("WEBKIT_INSPECTOR_PORT is out of range: %s. Falling back to dynamic port", inspectorPortStr);
+            port = 0;
+        }
+        inspectorAddress = adoptGRef(G_SOCKET_ADDRESS(g_inet_socket_address_new(g_inet_socket_address_get_address(G_INET_SOCKET_ADDRESS(inspectorHTTPAddress.get())), port)));
+    }
     else
         inspectorAddress = parseAddress(address);
     if (!inspectorHTTPAddress && !inspectorAddress) {


### PR DESCRIPTION
Controlled by env WEBKIT_INSPECTOR_PORT