### PR TITLE
[ARRISEOS-44125][MSE][GStreamer] Missing support for aborts not followed by an initialization segment

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -927,10 +927,8 @@ void AppendPipeline::resetPipeline()
     ASSERT(WTF::isMainThread());
     GST_DEBUG("resetting pipeline");
 
-    // gst_element_send_event(m_appsrc.get(), gst_event_new_flush_start());
-    // gst_element_send_event(m_appsrc.get(), gst_event_new_flush_stop(true));
-
-    gst_element_seek(m_pipeline.get(), 1.0, GST_FORMAT_BYTES, GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET, 0, GST_SEEK_TYPE_SET, GST_CLOCK_TIME_NONE);
+    gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
+    gst_element_get_state(m_pipeline.get(), nullptr, nullptr, 0);
 
 #if (!(LOG_DISABLED || defined(GST_DISABLE_GST_DEBUG)))
     {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -242,11 +242,13 @@ AppendPipeline::AppendPipeline(Ref<MediaSourceClientGStreamerMSE> mediaSourceCli
     }, this, nullptr);
 
     const String& type = m_sourceBufferPrivate->type().containerType();
-    if (type.endsWith("mp4"))
+    if (type.endsWith("mp4")) {
         m_demux = gst_element_factory_make("qtdemux", nullptr);
-    else if (type.endsWith("webm"))
+        GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_simple("video/quicktime", "variant", G_TYPE_STRING, "mse-bytestream", NULL));
+        gst_app_src_set_caps(GST_APP_SRC(m_appsrc.get()), caps.get());
+    } else if (type.endsWith("webm")) {
         m_demux = gst_element_factory_make("matroskademux", nullptr);
-    else
+    } else
         ASSERT_NOT_REACHED();
 
     m_appsink = gst_element_factory_make("appsink", nullptr);
@@ -927,8 +929,21 @@ void AppendPipeline::resetPipeline()
     ASSERT(WTF::isMainThread());
     GST_DEBUG("resetting pipeline");
 
-    gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
-    gst_element_get_state(m_pipeline.get(), nullptr, nullptr, 0);
+    // This function restores the GStreamer pipeline to the same state it was when the AppendPipeline constructor
+    // finished. All previously enqueued data is lost and the demuxer is flushed, but retains the configuration from the
+    // last received init segment, in accordance to the spec.
+
+    // Flush approach requires these GStreamer patches:
+    // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4101.
+    // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4199.
+
+    GST_DEBUG_OBJECT(pipeline(), "Handling resetParserState() in AppendPipeline by flushing the pipeline");
+    gst_element_send_event(m_appsrc.get(), gst_event_new_flush_start());
+    gst_element_send_event(m_appsrc.get(), gst_event_new_flush_stop(true));
+
+    GstSegment segment;
+    gst_segment_init(&segment, GST_FORMAT_BYTES);
+    gst_element_send_event(m_appsrc.get(), gst_event_new_segment(&segment));
 
 #if (!(LOG_DISABLED || defined(GST_DISABLE_GST_DEBUG)))
     {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=228820

This patch performs a flush on the AppendPipeline on SourceBuffer::abort().
Such action drains the AppendPipeline but leaves the demuxer still configured with
the context provided by the last init segment. This is in compliance with the spec,
which mandates that there's no need to append an init segment after an abort,
because the last one should be reused.

For this patch to work, the following GStreamer merge requests, scheduled to be
landed on 1.23.1, must be present:
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4101.
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4199.

If the GStreamer version is lower than the required one, the old reset technique,
consisting of setting the pipeline to READY and then PLAYING, is applied.

In the current circumstances, the layout tests still don't pass, so this patch
isn't unskipping them yet. media-mp4-h264-partial-abort.html should be unskipped
when we start using a GStreamer version that includes the MRs.
media-webm-opus-partial-abort.html should be unskipped when
https://github.com/WebKit/WebKit/pull/11807 lands.

See: https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1016

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::resetParserState): If supported by GStreamer, perform a flush instead of setting the pipeline state to READY and then again to PLAYING.