### PR TITLE
ONEM-31369: Implement mixed content whitelist

### DIFF
--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -44,6 +44,8 @@
 
 namespace WebCore {
 
+WTF::Vector<WTF::KeyValuePair<WTF::String, WTF::String>> MixedContentChecker::m_whitelist = {};
+
 // static
 bool MixedContentChecker::isMixedContent(SecurityOrigin& securityOrigin, const URL& url)
 {
@@ -69,7 +71,7 @@ bool MixedContentChecker::canDisplayInsecureContent(Frame& frame, SecurityOrigin
     if (!frame.document()->contentSecurityPolicy()->allowRunningOrDisplayingInsecureContent(url))
         return false;
 
-    if (SecurityPolicy::isAccessAllowed(securityOrigin, url)) {
+    if (isWhitelisted(securityOrigin.toString(), url.protocolHostAndPort())) {
         logWarning(frame, true, "display"_s, url);
         return true;
     }
@@ -97,7 +99,7 @@ bool MixedContentChecker::canRunInsecureContent(Frame& frame, SecurityOrigin& se
     if (!frame.document()->contentSecurityPolicy()->allowRunningOrDisplayingInsecureContent(url))
         return false;
 
-    if (SecurityPolicy::isAccessAllowed(securityOrigin, url)) {
+    if (isWhitelisted(securityOrigin.toString(), url.protocolHostAndPort())) {
         logWarning(frame, true, "run"_s, url);
         return true;
     }
@@ -149,6 +151,64 @@ std::optional<String> MixedContentChecker::checkForMixedContentInFrameTree(const
     }
     
     return std::nullopt;
+}
+
+bool wildcardMatch(const String& pattern, const String& url)
+{
+    int patternLen = pattern.length();
+    int patternPos = 0;
+    int urlLen = url.length();
+    int urlPos = 0;
+    int wildcardPos = -1;
+    int wildcardMatchEnd = 0;
+
+    while (urlPos < urlLen) {
+        if (patternPos < patternLen && pattern[patternPos] == url[urlPos]) {
+            // characters match
+            patternPos++;
+            urlPos++;
+        } else if (patternPos < patternLen && pattern[patternPos] == '*') {
+            // mark wildcard position, start matching the rest of the pattern
+            wildcardPos = patternPos;
+            wildcardMatchEnd = urlPos;
+            patternPos++;
+        } else if (wildcardPos != -1) {
+            // no match, but we have a wildcard - assume wildcard handles a match to this position,
+            // revert patternPos to after last *
+            patternPos = wildcardPos + 1;
+            wildcardMatchEnd++;
+            urlPos = wildcardMatchEnd;
+        } else {
+            // no match, no wildcard - pattern does not match
+            return false;
+        }
+    }
+
+    // url matches so far, and we're at the end of it
+    // skip any remaining wildcards
+    while (patternPos < patternLen && pattern[patternPos] == '*') {
+        patternPos++;
+    }
+    // if we're at the end of pattern, that's a match
+    // otherwise, the remaining part of the pattern can't be matched
+    return patternPos == patternLen;
+}
+
+//static
+bool MixedContentChecker::isWhitelisted(const String& origin, const String& domain)
+{
+    for (auto kvPair : m_whitelist) {
+        if (wildcardMatch(kvPair.key, origin) && wildcardMatch(kvPair.value, domain)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+//static
+void MixedContentChecker::addMixedContentWhitelistEntry(const String& origin, const String& domain)
+{
+    MixedContentChecker::m_whitelist.append(makeKeyValuePair(origin, domain));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -33,6 +33,8 @@
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -59,6 +61,12 @@ public:
     static void checkFormForMixedContent(Frame&, SecurityOrigin&, const URL&);
     static bool isMixedContent(SecurityOrigin&, const URL&);
     static std::optional<String> checkForMixedContentInFrameTree(const Frame&, const URL&);
+
+    static void addMixedContentWhitelistEntry(const String& origin, const String& domain);
+
+private:
+    static bool isWhitelisted(const String& origin, const String& domain);
+    static WTF::Vector<WTF::KeyValuePair<WTF::String, WTF::String>> m_whitelist;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -280,6 +280,27 @@ void webkit_web_extension_reset_origin_access_whitelists(WebKitWebExtension* ext
     extension->priv->bundle->resetOriginAccessAllowLists();
 }
 
+void webkit_web_extension_add_mixed_content_whitelist_entry(WebKitWebExtension *extension, const gchar* origin, const gchar* domain)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->addMixedContentWhitelistEntry(String::fromUTF8(origin), String::fromUTF8(domain));
+}
+
+void webkit_web_extension_remove_mixed_content_whitelist_entry(WebKitWebExtension *extension, const gchar* origin, const gchar* domain)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->removeMixedContentWhitelistEntry(String::fromUTF8(origin), String::fromUTF8(domain));
+}
+
+void webkit_web_extension_reset_mixed_content_whitelist_entry(WebKitWebExtension *extension)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->bundle->resetMixedContentWhitelist();
+}
+
 /**
  * webkit_web_extension_send_message_to_context:
  * @extension: a #WebKitWebExtension

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/WebKitWebExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/WebKitWebExtension.h
@@ -102,6 +102,19 @@ WEBKIT_API void
 webkit_web_extension_reset_origin_access_whitelists       (WebKitWebExtension   *extension);
 
 WEBKIT_API void
+webkit_web_extension_add_mixed_content_whitelist_entry    (WebKitWebExtension   *extension,
+                                                           const gchar          *origin,
+                                                           const gchar          *domain);
+
+WEBKIT_API void
+webkit_web_extension_remove_mixed_content_whitelist_entry (WebKitWebExtension   *extension,
+                                                           const gchar          *origin,
+                                                           const gchar          *domain);
+
+WEBKIT_API void
+webkit_web_extension_reset_mixed_content_whitelist_entry  (WebKitWebExtension   *extension);
+
+WEBKIT_API void
 webkit_web_extension_send_message_to_context        (WebKitWebExtension *extension,
                                                      WebKitUserMessage  *message,
                                                      GCancellable       *cancellable,

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -83,6 +83,8 @@
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/SystemTracing.h>
 
+#include <WebCore/MixedContentChecker.h>
+
 #if ENABLE(NOTIFICATIONS)
 #include "WebNotificationManager.h"
 #endif
@@ -169,6 +171,20 @@ void InjectedBundle::resetOriginAccessAllowLists()
 {
     SecurityPolicy::resetOriginAccessAllowlists();
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ResetOriginAccessAllowLists { }, 0);
+}
+
+void InjectedBundle::addMixedContentWhitelistEntry(const String& origin, const String& domain)
+{
+    MixedContentChecker::addMixedContentWhitelistEntry(origin, domain);
+}
+
+void InjectedBundle::removeMixedContentWhitelistEntry(const String& origin, const String& domain)
+{
+    //TODO
+}
+void InjectedBundle::resetMixedContentWhitelist()
+{
+    //TODO
 }
 
 void InjectedBundle::setAsynchronousSpellCheckingEnabled(bool enabled)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
@@ -99,6 +99,9 @@ public:
     void addOriginAccessAllowListEntry(const String&, const String&, const String&, bool);
     void removeOriginAccessAllowListEntry(const String&, const String&, const String&, bool);
     void resetOriginAccessAllowLists();
+    void addMixedContentWhitelistEntry(const String&, const String&);
+    void removeMixedContentWhitelistEntry(const String&, const String&);
+    void resetMixedContentWhitelist();
     void setAsynchronousSpellCheckingEnabled(bool);
     int numberOfPages(WebFrame*, double, double);
     int pageNumberForElementById(WebFrame*, const String&, double, double);


### PR DESCRIPTION
Passed via extension API webkit_web_extension_add_mixed_content_whitelist_entry
Wildcards are supported