### PR TITLE
ONEM-30704: Release egl thread when EGL context is destructed

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
@@ -46,7 +46,6 @@
 #endif
 
 #include <wtf/Vector.h>
-#include <unistd.h>
 
 namespace WebCore {
 
@@ -403,7 +402,6 @@ GLContextEGL::~GLContextEGL()
     destroyWPETarget();
 #endif
 
-    WTFLogAlways("ONEM-30704: release egl thread, pid = %d tid = %d", getpid(), gettid());
     eglReleaseThread();
 }
 

--- a/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
@@ -401,6 +401,9 @@ GLContextEGL::~GLContextEGL()
 #if USE(WPE_RENDERER)
     destroyWPETarget();
 #endif
+
+    WTFLogAlways("ONEM-30704: release egl thread, pid = %d tid = %d", getpid(), gettid());
+    eglReleaseThread();
 }
 
 EGLImage GLContextEGL::createImage(EGLenum target, EGLClientBuffer clientBuffer, const Vector<EGLAttrib>& attribList) const

--- a/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #include <wtf/Vector.h>
+#include <unistd.h>
 
 namespace WebCore {
 
@@ -401,6 +402,9 @@ GLContextEGL::~GLContextEGL()
 #if USE(WPE_RENDERER)
     destroyWPETarget();
 #endif
+
+    WTFLogAlways("ONEM-30704: release egl thread, pid = %d tid = %d", getpid(), gettid());
+    eglReleaseThread();
 }
 
 EGLImage GLContextEGL::createImage(EGLenum target, EGLClientBuffer clientBuffer, const Vector<EGLAttrib>& attribList) const

--- a/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGL.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #include <wtf/Vector.h>
+#include <unistd.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
When EGL context is destructed, EGL thread created during construction is
not released which leads to core dump during the thread termination
since thread is not joinable.
