### PR TITLE
Fixes for apple tv

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-detach-crash.html
+++ b/LayoutTests/media/media-source/media-source-seek-detach-crash.html
@@ -52,6 +52,7 @@
         run('sourceBuffer.appendBuffer(loader.initSegment())');
         setTimeout(() => { run('video.currentTime = 2'); });
         video.addEventListener('error', endTestLater);
+        waitForEventOn(sourceBuffer, 'update', failTest, false, true);
     }
     </script>
 </head>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1861,7 +1861,6 @@ webkit.org/b/189343 imported/w3c/web-platform-tests/xhr/sync-no-timeout.any.html
 webkit.org/b/189345 http/tests/media/clearkey/collect-webkit-media-session.html [ Skip ]
 
 media/encrypted-media [ Pass ]
-media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Pass ]
 
 webkit.org/b/205857 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Skip ]
 webkit.org/b/205860 media/encrypted-media/mock-MediaKeySession-remove.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -800,14 +800,7 @@ std::pair<AppendPipeline::CreateTrackResult, AppendPipeline::Track*> AppendPipel
     auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(demuxerSrcPad)).get());
     GST_DEBUG_OBJECT(pipeline(), "Demuxer src pad caps: %" GST_PTR_FORMAT, parsedCaps.get());
 
-    if (streamType == StreamType::Invalid) {
-        GST_WARNING_OBJECT(pipeline(), "Unsupported track codec: %" GST_PTR_FORMAT, parsedCaps.get());
-        // 3.5.7 Initialization Segment Received
-        // 5.1. If the initialization segment contains tracks with codecs the user agent does not support, then run the
-        // append error algorithm and abort these steps.
-        return { CreateTrackResult::AppendParsingFailed, nullptr };
-    }
-    if (streamType == StreamType::Unknown) {
+    if (streamType == StreamType::Invalid || streamType == StreamType::Unknown) {
         GST_WARNING_OBJECT(pipeline(), "Pad '%s' with parsed caps %" GST_PTR_FORMAT " has an unknown type, will be connected to a black hole probe.", GST_PAD_NAME(demuxerSrcPad), parsedCaps.get());
         gst_pad_add_probe(demuxerSrcPad, GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelineDemuxerBlackHolePadProbe), nullptr, nullptr);
         return { CreateTrackResult::TrackIgnored, nullptr };
@@ -832,6 +825,13 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
     auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(demuxerSrcPad)).get());
 
     GST_DEBUG_OBJECT(demuxerSrcPad, "Caps: %" GST_PTR_FORMAT, parsedCaps.get());
+    if (streamType == StreamType::Invalid) {
+        // Invalid configuration.
+        GST_WARNING_OBJECT(pipeline(), "Couldn't find a matching pre-existing track for pad '%s' with parsed caps %" GST_PTR_FORMAT
+            " ignoring, connecting to a black hole probe.", GST_PAD_NAME(demuxerSrcPad), parsedCaps.get());
+        gst_pad_add_probe(demuxerSrcPad, GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelineDemuxerBlackHolePadProbe), nullptr, nullptr);
+        return true;
+    }
 
     // Try to find a matching pre-existing track. Ideally, tracks should be matched by track ID, but matching by type
     // is provided as a fallback -- which will be used, since we don't have a way to fetch those from GStreamer at the moment.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -459,36 +459,58 @@ void AppendPipeline::didReceiveInitializationSegment()
             trackIndex++;
         }
     } else {
-        // Since we don't rely on the demuxer pad-added signal and this pipeline is not
-        // stream-aware, we need to account for stream topology changes ourselves.
-        unsigned videoPadsCount = 0;
-        unsigned audioPadsCount = 0;
-        unsigned textPadsCount = 0;
+        HashSet<String> videoPadStreamIDs;
+        HashSet<String> audioPadStreamIDs;
+        HashSet<String> textPadStreamIDs;
         for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
-            if (gst_pad_is_linked(pad))
-                continue;
             auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(pad)).get());
+            UNUSED_VARIABLE(parsedCaps);
+            UNUSED_VARIABLE(presentationSize);
+            String streamID = String::fromLatin1(GUniquePtr<char>(gst_pad_get_stream_id(pad)).get());
             if (streamType == StreamType::Audio)
-                audioPadsCount++;
+                audioPadStreamIDs.add(WTFMove(streamID));
             else if (streamType == StreamType::Video)
-                videoPadsCount++;
+                videoPadStreamIDs.add(WTFMove(streamID));
             else if (streamType == StreamType::Text)
-                textPadsCount++;
+                textPadStreamIDs.add(WTFMove(streamID));
         }
 
         unsigned videoTracksCount = 0;
         unsigned audioTracksCount = 0;
         unsigned textTracksCount = 0;
+        bool doAudioTrackStreamIDsMatch = true;
+        bool doVideoTrackStreamIDsMatch = true;
+        bool doTextTrackStreamIDsMatch = true;
         for (const auto& track : m_tracks) {
-            if (track->streamType == StreamType::Audio)
+            GUniquePtr<char> streamIDAsCharacters(gst_pad_get_stream_id(track->entryPad.get()));
+            String streamID = String::fromLatin1(streamIDAsCharacters.get());
+            if (track->streamType == StreamType::Audio) {
                 audioTracksCount++;
-            else if (track->streamType == StreamType::Video)
+                if (streamID.isEmpty() || !audioPadStreamIDs.contains(streamID))
+                    doAudioTrackStreamIDsMatch = false;
+            } else if (track->streamType == StreamType::Video) {
                 videoTracksCount++;
-            else if (track->streamType == StreamType::Text)
+                if (streamID.isEmpty() || !videoPadStreamIDs.contains(streamID))
+                    doVideoTrackStreamIDsMatch = false;
+            } else if (track->streamType == StreamType::Text) {
                 textTracksCount++;
+                if (streamID.isEmpty() || !textPadStreamIDs.contains(streamID))
+                    doTextTrackStreamIDsMatch = false;
+            }
         }
 
-        if (videoPadsCount < videoTracksCount || audioPadsCount < audioTracksCount || textPadsCount < textTracksCount) {
+        // Step 3 of the MSE spec append initialization segment algorithm.
+        // 4.5.7.3.1: Verify the following properties. If any of the checks fail then run the append error algorithm and abort these steps.
+        // 4.5.7.3.1.1: The number of audio, video, and text tracks match what was in the first initialization segment.
+        bool doTracksMatch = audioPadStreamIDs.size() == audioTracksCount && videoPadStreamIDs.size() == videoTracksCount && textPadStreamIDs.size() == textTracksCount;
+        // 4.5.7.3.1.2: If more than one track for a single type are present (e.g., 2 audio tracks), then the Track IDs match the ones in the first initialization segment.
+        if (doTracksMatch && audioTracksCount > 1)
+            doTracksMatch = doAudioTrackStreamIDsMatch;
+        if (doTracksMatch && videoTracksCount > 1)
+            doTracksMatch = doVideoTrackStreamIDsMatch;
+        if (doTracksMatch && textTracksCount > 1)
+            doTracksMatch = doTextTrackStreamIDsMatch;
+        if (!doTracksMatch) {
             GST_WARNING_OBJECT(pipeline(), "New demuxed stream topology doesn't match the existing tracks topology");
             m_sourceBufferPrivate.appendParsingFailed();
             return;
@@ -830,7 +852,8 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
         return false;
     }
 
-    if (!matchingTrack->isLinked())
+    GRefPtr<GstCaps> matchingTrackCaps = adoptGRef(gst_pad_get_current_caps(matchingTrack->entryPad.get()));
+    if (!matchingTrack->isLinked() && (!matchingTrackCaps || gst_caps_can_intersect(parsedCaps.get(), matchingTrackCaps.get())))
         linkPadWithTrack(demuxerSrcPad, *matchingTrack);
     else {
         // Unlink from old track and link to new track, by 1. stopping parser/sink, 2. unlinking
@@ -841,8 +864,10 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
 
         auto peer = adoptGRef(gst_pad_get_peer(matchingTrack->entryPad.get()));
         if (peer.get() != demuxerSrcPad) {
-            GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %s", matchingTrack->trackId.string().ascii().data());
-            gst_pad_unlink(peer.get(), matchingTrack->entryPad.get());
+            if (peer) {
+                GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %s", matchingTrack->trackId.string().ascii().data());
+                gst_pad_unlink(peer.get(), matchingTrack->entryPad.get());
+            }
 
             const String& type = m_sourceBufferPrivate.type().containerType();
             if (type.endsWith("webm"_s))

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -103,6 +103,10 @@ static gboolean webKitMediaSrcSendEvent(GstElement*, GstEvent*);
 
 struct WebKitMediaSrcPadPrivate {
     RefPtr<Stream> stream;
+
+#if ENABLE(ENCRYPTED_MEDIA)
+    gulong decryptorProbeId;
+#endif
 };
 
 struct WebKitMediaSrcPad {
@@ -294,6 +298,158 @@ static void webKitMediaSrcConstructed(GObject* object)
     GST_OBJECT_FLAG_SET(object, GST_ELEMENT_FLAG_SOURCE);
 }
 
+#if ENABLE(ENCRYPTED_MEDIA)
+GstElement* createDecryptor(const char* requestedProtectionSystemUuid)
+{
+    GstElement* decryptor = nullptr;
+    GList* decryptors = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECRYPTOR, GST_RANK_MARGINAL);
+
+    // Prefer WebKit decryptors
+    decryptors = g_list_sort(decryptors, [](gconstpointer p1, gconstpointer p2) -> gint {
+        GstPluginFeature *f1, *f2;
+        const gchar* name;
+        f1 = (GstPluginFeature *) p1;
+        f2 = (GstPluginFeature *) p2;
+        if ((name = gst_plugin_feature_get_name(f1)) && g_str_has_prefix(name, "webkit"))
+            return -1;
+        if ((name = gst_plugin_feature_get_name(f2)) && g_str_has_prefix(name, "webkit"))
+            return 1;
+        return gst_plugin_feature_rank_compare_func(p1, p2);
+    });
+
+    for (GList* walk = decryptors; !decryptor && walk; walk = g_list_next(walk)) {
+        GstElementFactory* factory = reinterpret_cast<GstElementFactory*>(walk->data);
+
+        for (const GList* current = gst_element_factory_get_static_pad_templates(factory); current && !decryptor; current = g_list_next(current)) {
+            GstStaticPadTemplate* staticPadTemplate = static_cast<GstStaticPadTemplate*>(current->data);
+            GRefPtr<GstCaps> caps = adoptGRef(gst_static_pad_template_get_caps(staticPadTemplate));
+            unsigned length = gst_caps_get_size(caps.get());
+
+            GST_TRACE("factory %s caps has size %u", GST_OBJECT_NAME(factory), length);
+            for (unsigned i = 0; !decryptor && i < length; ++i) {
+                GstStructure* structure = gst_caps_get_structure(caps.get(), i);
+                GST_TRACE("checking structure %s", gst_structure_get_name(structure));
+                if (gst_structure_has_field_typed(structure, GST_PROTECTION_SYSTEM_ID_CAPS_FIELD, G_TYPE_STRING)) {
+                    const char* protectionSystemUuid = gst_structure_get_string(structure, GST_PROTECTION_SYSTEM_ID_CAPS_FIELD);
+                    GST_TRACE("structure %s has protection system %s", gst_structure_get_name(structure), protectionSystemUuid);
+                    if (!g_ascii_strcasecmp(requestedProtectionSystemUuid, protectionSystemUuid)) {
+                        GST_DEBUG("found decryptor %s for %s", GST_OBJECT_NAME(factory), requestedProtectionSystemUuid);
+                        decryptor = gst_element_factory_create(factory, nullptr);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    gst_plugin_feature_list_free(decryptors);
+    GST_TRACE("returning decryptor %p", decryptor);
+    return decryptor;
+}
+
+typedef struct _DecryptorProbeData DecryptorProbeData;
+struct _DecryptorProbeData
+{
+    _DecryptorProbeData(WebKitMediaSrc* parent)
+        : parent(parent) {
+    }
+    ~_DecryptorProbeData() {
+        GST_WARNING("Destroying Decryptor probe, decryptor=%p(attached: %s)",
+                    decryptor.get(), decryptorAttached ? "yes" : "no");
+    }
+    WebKitMediaSrc* parent;
+    GRefPtr<GstElement> decryptor;
+    bool decryptorAttached { false };
+    bool didFail { false };
+    WTF_MAKE_NONCOPYABLE(_DecryptorProbeData);
+};
+
+GstPadProbeReturn onWebKitMediaSourcePadEvent(GstPad* pad, GstPadProbeInfo* info, gpointer data)
+{
+    if (!(GST_PAD_PROBE_INFO_TYPE (info) & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM))
+        return GST_PAD_PROBE_OK;
+
+    GstEvent *event = GST_PAD_PROBE_INFO_EVENT (info);
+    if (GST_EVENT_TYPE (event) != GST_EVENT_CAPS)
+        return GST_PAD_PROBE_OK;
+
+    DecryptorProbeData* probData = reinterpret_cast<DecryptorProbeData*>(data);
+    if (probData->didFail)
+        return GST_PAD_PROBE_OK;
+
+    GstCaps* caps = nullptr;
+    gst_event_parse_caps(event, &caps);
+
+    if (!caps)
+        return GST_PAD_PROBE_OK;
+
+    // urisourcebin > webkitmediasrc > pad
+    GRefPtr<GstBin> parent_bin = adoptGRef(GST_BIN(gst_element_get_parent(probData->parent)));
+
+    GstElement* decryptor = probData->decryptor.get();
+    bool decryptorAttached = decryptor && probData->decryptorAttached;
+
+    if(!decryptorAttached && WebCore::areEncryptedCaps(caps))
+    {
+        if(!decryptor)
+        {
+            GstStructure* structure = gst_caps_get_structure(caps, 0);
+            probData->decryptor = createDecryptor(gst_structure_get_string(structure, "protection-system"));
+            decryptor = probData->decryptor.get();
+            if (!decryptor)
+            {
+                GST_ERROR("Failed to create decryptor");
+                probData->didFail = true;
+                return GST_PAD_PROBE_OK;
+            }
+
+            gst_bin_add(parent_bin.get(), decryptor);
+        }
+
+        GST_DEBUG("padname: %s Got CAPS=%" GST_PTR_FORMAT ", Add decryptor %" GST_PTR_FORMAT, GST_PAD_NAME(pad), caps, decryptor);
+
+        gst_element_sync_state_with_parent(decryptor);
+
+        GRefPtr<GstPad> decryptorSinkPad = adoptGRef(gst_element_get_static_pad(decryptor, "sink"));
+        GRefPtr<GstPad> decryptorSrcPad = adoptGRef(gst_element_get_static_pad(decryptor, "src"));
+        GstPad *srcPad = pad;
+        GstPadLinkReturn rc;
+
+        GRefPtr<GstPad> peerPad = adoptGRef(gst_pad_get_peer(srcPad));
+
+        // Insert decryptor between mediasrc and the decodebin
+        if (!gst_pad_unlink(srcPad, peerPad.get()))
+            GST_ERROR("Failed to unlink '%s' src pad", GST_PAD_NAME(pad));
+        else if (GST_PAD_LINK_OK != (rc = gst_pad_link_full(srcPad, decryptorSinkPad.get(), GST_PAD_LINK_CHECK_NOTHING)))
+            GST_ERROR("Failed to link pad to decryptorSinkPad, rc = %d", rc);
+        else if (GST_PAD_LINK_OK != (rc = gst_pad_link(decryptorSrcPad.get(), peerPad.get())))
+            GST_ERROR("Failed to link decryptorSrcPad to app sink, rc = %d", rc);
+
+        probData->decryptorAttached = true;
+    } else if (decryptorAttached && !WebCore::areEncryptedCaps(caps)) {
+        GST_DEBUG("padname: %s Got CAPS=%" GST_PTR_FORMAT ", Remove decryptor %" GST_PTR_FORMAT, GST_PAD_NAME(pad), caps, decryptor);
+
+        GRefPtr<GstPad> decryptorSinkPad = adoptGRef(gst_element_get_static_pad(decryptor, "sink"));
+        GRefPtr<GstPad> decryptorSrcPad = adoptGRef(gst_element_get_static_pad(decryptor, "src"));
+        GRefPtr<GstPad> peerPad = adoptGRef(gst_pad_get_peer(decryptorSrcPad.get()));
+        GstPad *srcPad = pad;
+        GstPadLinkReturn rc;
+
+        if (!gst_pad_unlink(decryptorSrcPad.get(), peerPad.get()))
+            GST_ERROR("Failed to unlink decryptorSrcPad");
+        else if (!gst_pad_unlink(srcPad, decryptorSinkPad.get()))
+            GST_ERROR("Failed to unlink decryptorSinkPad");
+        else if (GST_PAD_LINK_OK != (rc = gst_pad_link(srcPad, peerPad.get())))
+            GST_ERROR("Failed to link '%s' to peer pad, rc = %d", GST_PAD_NAME(pad), rc);
+
+        probData->decryptorAttached = false;
+    } else {
+        GST_DEBUG("padname: %s Got CAPS %" GST_PTR_FORMAT ", decryptorAttached = %s, caps are encrypted= %s",
+                GST_PAD_NAME(pad), caps, decryptorAttached ? "yes" : "no", WebCore::areEncryptedCaps(caps) ? "yes" : "no");
+    }
+    return GST_PAD_PROBE_OK;
+}
+#endif
+
 void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<MediaSourceTrackGStreamer>>& tracks)
 {
     ASSERT(isMainThread());
@@ -330,6 +486,12 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
             if (state > GST_STATE_READY)
                 gst_pad_set_active(GST_PAD(stream->pad.get()), true);
         }
+#if ENABLE(ENCRYPTED_MEDIA)
+        WEBKIT_MEDIA_SRC_PAD(stream->pad.get())->priv->decryptorProbeId =
+            gst_pad_add_probe(stream->pad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM,
+                    onWebKitMediaSourcePadEvent, new DecryptorProbeData(source),
+                    [](gpointer data) { delete static_cast<DecryptorProbeData*>(data); });
+#endif
         GST_DEBUG_OBJECT(source, "Adding pad '%s' for stream with name '%s'", GST_OBJECT_NAME(stream->pad.get()), stream->track->trackId().string().utf8().data());
         gst_element_add_pad(GST_ELEMENT(source), GST_PAD(stream->pad.get()));
     }
@@ -347,8 +509,12 @@ static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomStrin
     // Stop the thread now.
     gst_pad_set_active(stream->pad.get(), false);
 
-    if (source->priv->isStarted())
+    if (source->priv->isStarted()) {
         gst_element_remove_pad(GST_ELEMENT(source), stream->pad.get());
+#if ENABLE(ENCRYPTED_MEDIA)
+        gst_pad_remove_probe(stream->pad.get(), WEBKIT_MEDIA_SRC_PAD(stream->pad.get())->priv->decryptorProbeId);
+#endif
+    }
     source->priv->streams.remove(name);
 }
 


### PR DESCRIPTION
1. Fix for counting streams (from upstream)
2. Ignore unknown tracks in AppendPipeline
3. Dynamically attach decryptor