### PR TITLE
ONEM-31902 Fix play/pause issues - state desynchronisation

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -147,7 +147,7 @@ public:
     void prepareToPlay() final;
     void play() override;
     void pause() override;
-    bool paused() const final;
+    bool paused() const;
     bool ended() const final;
     bool seeking() const override { return m_isSeeking; }
     void seek(const MediaTime&) override;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -55,6 +55,7 @@ public:
 
     void play() override;
     void pause() override;
+    bool paused() const override;
     void seek(const MediaTime&) override;
     bool doSeek(const MediaTime&, float rate, GstSeekFlags) override;
 
@@ -110,7 +111,6 @@ private:
     WeakPtr<MediaSourcePrivateClient> m_mediaSource;
     RefPtr<MediaSourcePrivateGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
-    bool m_isPipelinePlaying = true;
     bool m_hasAllTracks = false;
     Vector<RefPtr<MediaSourceTrackGStreamer>> m_tracks;
 


### PR DESCRIPTION
This fix addresses two issues with play/pause functionality introduced by the following commit:
https://github.com/WebKit/WebKit/commit/9382c6ef1a5b64d1701c691c63fe84de22cf932b

The first issue was with video pausing. At some point pause button was stop working because WPE state held in m_isPipelinePlaying was inconsistent with the real state the pipeline was currently in - the pipeline was playing but from WPE perspective the pipeline was paused.
The fix removes the state copy held by MediaPlayerPrivateGStreamerMSE:: m_isPipelinePlaying and instead always read current state from the pipeline.

The second issue addressed by this commit was observed when pausing a video just after seek ended. That was sometimes causing the MediaPlayerPrivateGStreamer::paused() to return incorrect state because m_isPlaybackRatePaused had incorrect value. That variable shouldn't be used anymore in MediaPlayerPrivateGStreamerMSE as that latter class has overriden play()/pause() functions from MediaPlayerPrivateGStreamer that originally were using the m_isPlaybackRatePaused variable but new versions of play()/pause() in MediaPlayerPrivateGStreamerMSE do not refer to it anymore.
Hence the MediaPlayerPrivateGStreamer::paused() was also overriden in this commit and the new implementation of that function does no longer use the m_isPlaybackRatePaused.
