### PR TITLE
ONEM-31902 Fix play/pause issues

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -377,6 +377,7 @@ protected:
     mutable std::optional<bool> m_isLiveStream;
     bool m_isPaused { true };
     float m_playbackRate { 1 };
+    bool m_isPlaybackRatePaused { false };
     GstState m_currentState { GST_STATE_NULL };
     GstState m_oldState { GST_STATE_NULL };
     GstState m_requestedState { GST_STATE_VOID_PENDING };
@@ -547,7 +548,6 @@ private:
     GRefPtr<GstElement> m_textSink;
     GUniquePtr<GstStructure> m_mediaLocations;
     int m_mediaLocationCurrentIndex { 0 };
-    bool m_isPlaybackRatePaused { false };
     MediaTime m_timeOfOverlappingSeek;
     // Last playback rate sent through a GStreamer seek.
     float m_lastPlaybackRate { 1 };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -208,6 +208,11 @@ void MediaPlayerPrivateGStreamerMSE::play()
 {
     GST_DEBUG_OBJECT(pipeline(), "Play requested");
     m_isPaused = false;
+        if (!m_playbackRate) {
+        // If the playback rate is 0, we should nor resume playback
+        m_isPlaybackRatePaused = true;
+        return;
+    }
     updateStates();
 }
 
@@ -215,6 +220,7 @@ void MediaPlayerPrivateGStreamerMSE::pause()
 {
     GST_DEBUG_OBJECT(pipeline(), "Pause requested");
     m_isPaused = true;
+    m_isPlaybackRatePaused = false;
     updateStates();
 }
 
@@ -356,8 +362,19 @@ void MediaPlayerPrivateGStreamerMSE::sourceSetup(GstElement* sourceElement)
 
 void MediaPlayerPrivateGStreamerMSE::updateStates()
 {
-    bool shouldBePlaying = !m_isPaused && readyState() >= MediaPlayer::ReadyState::HaveFutureData;
+    bool shouldBePlaying = !m_isPaused && !m_isPlaybackRatePaused && readyState() >= MediaPlayer::ReadyState::HaveFutureData;
     GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s", boolForPrinting(shouldBePlaying), boolForPrinting(m_isPipelinePlaying));
+
+    GstState state, pending;
+    GstStateChangeReturn getStateResult = gst_element_get_state(pipeline(), &state, &pending, 0);
+    if (getStateResult == GST_STATE_CHANGE_ASYNC) {
+        // Changeing pipeline state during async state change will be either rejected by changePipelineState()
+        // or ignored by playbin (overwritten by the async tartet state after transitions completes).
+        // Lets wait until it's done and then apply play/pause if needed
+        GST_DEBUG_OBJECT(pipeline(), "ASYNC state change in progress");
+        return;
+    }
+
     if (shouldBePlaying && !m_isPipelinePlaying) {
         if (!changePipelineState(GST_STATE_PLAYING))
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PLAYING failed");
@@ -366,6 +383,11 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
         if (!changePipelineState(GST_STATE_PAUSED))
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PAUSED failed");
         m_isPipelinePlaying = false;
+    }
+
+    if (getStateResult == GST_STATE_CHANGE_SUCCESS && state >= GST_STATE_PAUSED) {
+        // Update playback rate that was set before the pipeline was prerolled.
+        updatePlaybackRate();
     }
 }
 


### PR DESCRIPTION
This change fixes the following issues observed in Channel4 but also in other apps (eg. Videoland):
- HTMLMediaElement.playbackRate returns 0 for the first few seconds of playback causing issue with pausing video in that state
- Triggering play/pause just before seek has ended causes issues with resuming playback or pausing it again

There is also a variant of the second issue from the ones mentioned above that is app-specific and cannot be fixed in WPE. That issue can lead to a situation when Channel4 shows advert with stream still being played underneath but user is able to recover from that state without further problems with playing/pausing video. This case will be covered by a separate ticket.
 
This commit is based on:
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1132

That pull request was still in progress while being cherry-picked in this pull request to lgi-wpe-2.38 branch. At that time it was pointing to the following commit:
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1132/commits/696f25651a87bdeab73e04db37a151f6da5a70e2

Any changes that are potentially going to be made in the source pull request afterwards will be added in next updates.
