### PR TITLE
ONEM-31005 Fix missing line/column/sourceURL in Error objects in JS

### DIFF
--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -241,13 +241,14 @@ bool ErrorInstance::materializeErrorInfoIfNeeded(VM& vm)
     computeErrorInfo(vm);
 
     if (!m_stackString.isNull()) {
-        auto attributes = static_cast<unsigned>(PropertyAttribute::DontEnum);
+        auto attributes = static_cast<unsigned>(PropertyAttribute::ReadOnly);
 
         putDirect(vm, vm.propertyNames->line, jsNumber(m_line), attributes);
         putDirect(vm, vm.propertyNames->column, jsNumber(m_column), attributes);
         if (!m_sourceURL.isEmpty())
             putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTFMove(m_sourceURL)), attributes);
 
+        attributes = static_cast<unsigned>(PropertyAttribute::DontEnum);
         putDirect(vm, vm.propertyNames->stack, jsString(vm, WTFMove(m_stackString)), attributes);
     }
 

--- a/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
@@ -100,7 +100,7 @@ void getEnumerablePropertyNames(JSGlobalObject* globalObject, JSObject* base, Pr
 
     auto getOwnPropertyNames = [&](JSObject* object) {
         auto mode = DontEnumPropertiesMode::Exclude;
-        if (object->type() == ProxyObjectType) {
+        if (object->type() == ProxyObjectType || object->type() == ErrorInstanceType) {
             // This ensures Proxy's [[GetOwnProperty]] trap is invoked only once per property, by OpHasEnumerableProperty.
             // Although doing this for all objects is spec-conformant, collecting DontEnum properties isn't free.
             mode = DontEnumPropertiesMode::Include;

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -76,7 +76,7 @@ String StackFrame::sourceURL(VM& vm) const
 
     if (!sourceURL.isNull())
         return sourceURL;
-    return emptyString();
+    return aboutBlankURL().string();
 }
 
 String StackFrame::functionName(VM& vm) const


### PR DESCRIPTION
This commit fixes the regression in WPE 2.38 that caused a number of important properties not being included in Error objects in JavaScript code. These properties are line/column/sourceUrl.

There were 3 changes required to restore the functionality from previous versions of WPE - in this case 2.22

1. For ErrorInstanceType the mode was changed to DontEnumPropertiesMode::Include. This mode gets passed to ErrorInstance::getOwnSpecialPropertyNames which causes the code for adding extra properties to be executed.

2. Additional difference betwen WPE 2.38 and 2.22 was in the way the extra properties are added to JS objects. By using PropertyAttribute::DontEnum these properties are not enumerable, meaning they are not taken into account when iterating over object's properties with (for .. in ..) loop. In order to change that behavior the PropertyAttribute::ReadOnly was used for the three properties: line/column/sourceURL so the behaviour from WPE 2.22 was restored.

3. StackVisitor::Frame::sourceURL() returns empty string ("") in WPE 2.38 instead of "about:blank" like it was in WPE 2.22. In order to change that, the value returned from that function in case of returning empty string was modified to return "about:blank". In WPE 2.22 the "about:blank" is returned from ScriptExecutable::sourceURL() via call to:
String sourceURL = m_codeBlock->ownerExecutable()->sourceURL() in that same function. For some reason ScriptExecutable::sourceURL() in WPE 2.38 was returning "" (empty) string therefore it was decided to return "about:blank" from the StackFrame::sourceURL(). This solution might also be safer since using ScriptExecutable::sourceUrl() is more global solution.