### PR TITLE
ONEM-32547: Disable progressive webm support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2824,6 +2824,12 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
     auto& gstRegistryScanner = GStreamerRegistryScanner::singleton();
     result = gstRegistryScanner.isContentTypeSupported(GStreamerRegistryScanner::Configuration::Decoding, parameters.type, parameters.contentTypesRequiringHardwareSupport);
 
+#if PLATFORM(BROADCOM)
+    if (String::fromLatin1("video/webm") == parameters.type.containerType()) {
+        result = MediaPlayer::SupportsType::IsNotSupported;
+    }
+#endif
+
     GST_DEBUG("Supported: %s", convertEnumerationToString(result).utf8().data());
     return result;
 }


### PR DESCRIPTION
It's not supported on wpe 2.22.
We were returning "maybe" in canPlayType calls for webm,
and as a result we were getting webm ads that we can't actually play