### PR TITLE
Revert "ONEM-32547: Disable progressive webm support"

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2831,12 +2831,6 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
     auto& gstRegistryScanner = GStreamerRegistryScanner::singleton();
     result = gstRegistryScanner.isContentTypeSupported(GStreamerRegistryScanner::Configuration::Decoding, parameters.type, parameters.contentTypesRequiringHardwareSupport);
 
-#if PLATFORM(BROADCOM)
-    if (String::fromLatin1("video/webm") == parameters.type.containerType()) {
-        result = MediaPlayer::SupportsType::IsNotSupported;
-    }
-#endif
-
     GST_DEBUG("Supported: %s", convertEnumerationToString(result).utf8().data());
     return result;
 }


### PR DESCRIPTION
This reverts commit 0350c1a8ef89d2f0f75cfe792fd4ec6438e352f7.