### PR TITLE
[ONEM-32729] - Inject mpegaudioparse gst plugin

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2925,6 +2925,21 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 
     ASSERT(!m_pipeline);
 
+#if PLATFORM(BCM_NEXUS)
+    {
+        auto registry = gst_registry_get();
+        GRefPtr<GstPluginFeature> brcmaudfilter = gst_registry_lookup_feature(registry, "brcmaudfilter");
+        GRefPtr<GstPluginFeature> mpegaudioparse = gst_registry_lookup_feature(registry, "mpegaudioparse");
+
+        if (brcmaudfilter && mpegaudioparse) {
+            GST_INFO("overriding mpegaudioparse rank with brcmaudfilter rank + 1");
+            gst_plugin_feature_set_rank(
+                mpegaudioparse.get(),
+                gst_plugin_feature_get_rank(brcmaudfilter.get()) + 1);
+        }
+    }
+#endif
+
     auto elementId = m_player->elementId();
     if (elementId.isEmpty())
         elementId = "media-player"_s;


### PR DESCRIPTION
gst duration API is failed for progressive MP3 content and also seeing seek operation is failed for progressive Audio playback.
Issue was seen on those lightning apps: Deezer, Radioline and Radio paradise.
Issue is not seen on audio only MSE apps (eg. BBC Sounds).

Root cause is gst_element_query_duration API is not giving correct value.

As a fix, we have addded MpegAudioParse plugin with ths fix is added by playbin before BrcmAudioFilter.
The similar patch was already integrated in WPE 2.22 earlier
https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/957/files

also similar an issue on MVT test case:
[ONEM-32729] :[MVT impacted] Test "PROG_MP3_MP3__Seek" fails randomly on Apollo

Reproduction steps for radio line application

Run Radioline
Play any podcast (e.g from "Popular Podcast" section on Home page)
Expected:
Total duration time should be displayed correctly, and progress bar should follow current timestamp
Actual
Total duration is not displayed correctly and progress bar is broken