### PR TITLE
[ONEM-30810]: WPE 2.38 Missing WEBKIT.GLib-GIO: debug logs

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -118,6 +118,13 @@
 #include <WebCore/CurlContext.h>
 #endif
 
+namespace {
+#if ENABLE(RDK_LOGGER)
+void glibLogHandler(const gchar*, GLogLevelFlags, const gchar *message, gpointer) {
+    RDK_LOG(RDK_LOG_DEBUG, RDK_LOG_CHANNEL(GLib-GIO), message);
+}
+#endif // ENABLE(RDK_LOGGER)
+} // namespace
 namespace WebKit {
 using namespace WebCore;
 
@@ -2471,6 +2478,9 @@ void NetworkProcess::initializeProcess(const AuxiliaryProcessInitializationParam
 {
 #if ENABLE(RDK_LOGGER)
     rdk_logger_init("/etc/debug.ini");
+    if (rdk_dbg_enabled(RDK_LOG_CHANNEL(GLib-GIO), RDK_LOG_DEBUG)) {
+        g_log_set_handler("GLib-GIO", G_LOG_LEVEL_DEBUG, glibLogHandler, nullptr);
+    }
 #endif
 }
 


### PR DESCRIPTION
gsocket' logs are missing for WPE 2.38 and similar logs, we can see in WPE 2.22..so, we have added the handler in webkit to handle the RDK logger.

mod=GLib-GIO

Logs snippet:
Oct 16 09:56:00 E0B7B1-APPSTB-301000142200 WPENetworkProcess[4012]: 231016-07:56:00.073844 [mod=GLib-GIO, lvl=DEBUG] [tid=15] GSocketClient: Starting new address enumeration
Oct 16 09:56:00 E0B7B1-APPSTB-301000142200 WPENetworkProcess[4012]: 231016-07:56:00.076265 [mod=GLib-GIO, lvl=DEBUG] [tid=15] GSocketClient: Address enumeration succeeded
Oct 16 09:56:00 E0B7B1-APPSTB-301000142200 WPENetworkProcess[4012]: 231016-07:56:00.076575 [mod=GLib-GIO, lvl=DEBUG] [tid=15] GSocketClient: Starting TCP connection attempt to 2a02:26f0:f700:48d::29f9
Oct 16 09:56:00 E0B7B1-APPSTB-301000142200 WPENetworkProcess[4012]: 231016-07:56:00.076993 [mod=GLib-GIO, lvl=DEBUG] [tid=15] GSocketClient: Connection attempt failed: Could not connect: Network is unreachable
Oct 16 09:56:00 E0B7B1-APPSTB-301000142200 WPENetworkProcess[4012]: 231016-07:56:00.077127 [mod=GLib-GIO, lvl=DEBUG] [tid=15] GSocketClient: Starting new address enumeration
Oct 16 09:56:00 E0B7B1-APPSTB-301000142200 WPENetworkProcess[4012]: 231016-07:56:00.077412 [mod=GLib-GIO, lvl=DEBUG] [tid=15] GSocketClient: Address enumeration succeeded