### PR TITLE
[ONEM-32477]: WPE 2.38 - port debug logs

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -284,9 +284,10 @@ void MemoryPressureHandler::measurementTimerFired()
 {
     size_t footprint = memoryFootprint();
     size_t footprintVideo = memoryFootprintVideo();
-#if PLATFORM(COCOA)
-    RELEASE_LOG(MemoryPressure, "Current memory footprint: %zu MB", footprint / MB);
-#endif
+    static size_t footprintPeak = 0;
+    if (footprintPeak < footprint)
+        footprintPeak = footprint;
+    RELEASE_LOG(MemoryPressure, "Current memory footprint: %zu MB, peak: %zu MB", footprint / MB, footprintPeak / MB);
     auto killThreshold = thresholdForMemoryKill(MemoryType::Normal);
     auto killThresholdVideo = thresholdForMemoryKill(MemoryType::Video);
     if ((killThreshold && footprint >= *killThreshold) || (killThresholdVideo && footprintVideo >= *killThresholdVideo)) {

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -71,6 +71,7 @@
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/RAMSize.h>
 #include <wtf/text/StringBuilder.h>
+#include "CairoUtilities.h"
 
 #if ENABLE(MEDIA_STREAM)
 #include "CanvasCaptureMediaStreamTrack.h"
@@ -505,10 +506,9 @@ WebGLRenderingContextBase* HTMLCanvasElement::getContextWebGL(WebGLVersion type,
         if ((type == WebGLVersion::WebGL1) != m_context->isWebGL1())
             return nullptr;
     }
-
-    if (!m_context)
-        return createContextWebGL(type, WTFMove(attrs));
-    return &downcast<WebGLRenderingContextBase>(*m_context);
+    auto context = (!m_context) ? createContextWebGL(type, WTFMove(attrs)) : &downcast<WebGLRenderingContextBase>(*m_context);
+    WebCore::renderingStarted();
+    return context;
 }
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -29,6 +29,7 @@
 
 #if USE(CAIRO)
 
+#include <atomic>
 #include "AffineTransform.h"
 #include "CairoUniquePtr.h"
 #include "Color.h"
@@ -50,6 +51,10 @@
 #if OS(WINDOWS)
 #include <cairo-win32.h>
 #endif
+
+namespace {
+    std::atomic_flag renderingStartedFlag = ATOMIC_FLAG_INIT;
+}
 
 namespace WebCore {
 
@@ -379,6 +384,24 @@ RefPtr<cairo_region_t> toCairoRegion(const Region& region)
 cairo_matrix_t toCairoMatrix(const AffineTransform& transform)
 {
     return cairo_matrix_t { transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f() };
+}
+
+void resetRenderingStartedFlag()
+{
+    WTFLogAlways("resetRenderingStartedFlag \n");
+    renderingStartedFlag.clear();
+}
+
+void setRenderingStartedFlag() {
+    WTFLogAlways("setRenderingStartedFlag \n");
+    renderingStartedFlag.test_and_set();
+}
+
+void renderingStarted()
+{
+    if (!renderingStartedFlag.test_and_set()) {
+        WTFLogAlways("renderingStarted\n");
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+
 #if USE(CAIRO)
 
 #include "GraphicsTypes.h"
@@ -98,6 +99,9 @@ void flipImageSurfaceVertically(cairo_surface_t*);
 RefPtr<cairo_region_t> toCairoRegion(const Region&);
 
 cairo_matrix_t toCairoMatrix(const AffineTransform&);
+void resetRenderingStartedFlag();
+void setRenderingStartedFlag();
+void renderingStarted();
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
@@ -53,7 +53,8 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
 {
     if (!font.platformData().size())
         return;
-
+    
+    renderingStarted();
     auto xOffset = point.x();
     Vector<cairo_glyph_t> cairoGlyphs(numGlyphs);
     {

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -137,6 +137,7 @@ void GraphicsContextGL::paintToCanvas(const GraphicsContextGLAttributes& sourceC
     context.scale(FloatSize(1, -1));
     context.translate(0, -imageSize.height());
     context.setImageInterpolationQuality(InterpolationQuality::DoNotInterpolate);
+    renderingStarted();
     context.drawNativeImage(*image, imageSize, FloatRect({ }, canvasSize), FloatRect({ }, imageSize), { CompositeOperator::Copy });
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "MediaPlayerPrivateGStreamer.h"
+#include "CairoUtilities.h"
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
@@ -1894,6 +1895,8 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
 
         if (!m_isLegacyPlaybin && currentState == GST_STATE_PAUSED && newState == GST_STATE_PLAYING)
             playbin3SendSelectStreamsIfAppropriate();
+	
+	WebCore::renderingStarted();
         updateStates();
         checkPlayingConsistency();
 

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -157,7 +157,14 @@ SoupNetworkSession::~SoupNetworkSession() = default;
 void SoupNetworkSession::setupLogger()
 {
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
-    if (LogNetwork.state != WTFLogChannelState::On || soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_LOGGER))
+     if (
+#if USE(RDK_LOGGER)
+        !rdk_dbg_enabled(RDK_LOG_CHANNEL(NETWORK), RDK_LOG_DEBUG)
+#else
+        LogNetwork.state != WTFLogChannelState::On
+#endif // USE(RDK_LOGGER)
+         || soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_LOGGER)
+    )
         return;
 
 #if USE(SOUP2)

--- a/Source/WebKit/Platform/IPC/Attachment.h
+++ b/Source/WebKit/Platform/IPC/Attachment.h
@@ -111,7 +111,7 @@ private:
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     UnixFileDescriptor m_fd;
-    size_t m_size;
+    size_t m_size { };
     CustomWriter m_customWriter;
 #elif OS(WINDOWS)
     HANDLE m_handle { INVALID_HANDLE_VALUE };

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -167,7 +167,7 @@ private:
     OptionSet<MessageFlags> m_messageFlags;
     MessageName m_messageName;
 
-    uint64_t m_destinationID;
+    uint64_t m_destinationID { };
 
 #if PLATFORM(MAC)
     ImportanceAssertion m_importanceAssertion;

--- a/Source/WebKit/Platform/Module.h
+++ b/Source/WebKit/Platform/Module.h
@@ -71,7 +71,7 @@ private:
 #if USE(CF)
     RetainPtr<CFBundleRef> m_bundle;
 #elif USE(GLIB)
-    GModule* m_handle;
+    GModule* m_handle = nullptr;
 #endif
 };
 

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -56,7 +56,7 @@ struct LoadParameters {
     void platformEncode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool platformDecode(IPC::Decoder&, LoadParameters&);
 
-    uint64_t navigationID;
+    uint64_t navigationID { };
 
     WebCore::ResourceRequest request;
     SandboxExtension::Handle sandboxExtensionHandle;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -63,7 +63,7 @@ struct HTTPBody {
 
         // File.
         String filePath;
-        int64_t fileStart;
+        int64_t fileStart { };
         std::optional<int64_t> fileLength;
         std::optional<WallTime> expectedFileModificationTime;
 

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -231,6 +231,8 @@ public:
     virtual void startXRSession(WebKit::WebPageProxy&, CompletionHandler<void(RetainPtr<id>)>&& completionHandler) { completionHandler(nil); }
     virtual void endXRSession(WebKit::WebPageProxy&) { }
 #endif
+    virtual void willAddDetailedMessageToConsole( WebKit::WebPageProxy&, const WTF::String& source, const WTF::String& level,
+            uint64_t line, uint64_t col, const WTF::String& message, const WTF::String& url) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2068,6 +2068,16 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             m_client.didResignInputElementStrongPasswordAppearance(toAPI(&page), toAPI(userInfo), m_client.base.clientInfo);
         }
 
+	void willAddDetailedMessageToConsole(WebPageProxy& page, const String& source, const String& level,
+            uint64_t line, uint64_t column, const String& message, const String& url) final
+        {
+            if (!m_client.willAddDetailedMessageToConsole)
+                return;
+            
+	    m_client.willAddDetailedMessageToConsole(toAPI(page), toAPI(source.impl()), toAPI(level.impl()),
+                    line, column, toAPI(message.impl()), toAPI(url.impl()), m_client.base.clientInfo);
+        }
+
 #if ENABLE(POINTER_LOCK)
         void requestPointerLock(WebPageProxy* page) final
         {

--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -83,7 +83,8 @@ WK_EXPORT void WKPageRunJavaScriptPromptResultListenerCall(WKPageRunJavaScriptPr
 
 WK_EXPORT WKTypeID WKPageRequestStorageAccessConfirmResultListenerGetTypeID(void);
 WK_EXPORT void WKPageRequestStorageAccessConfirmResultListenerCall(WKPageRequestStorageAccessConfirmResultListenerRef listener, bool result);
-    
+
+typedef void (*WKPageWillAddDetailedMessageToConsoleCallback)(WKPageRef page, WKStringRef source, WKStringRef level, uint64_t line, uint64_t column, WKStringRef message, WKStringRef url, const void* clientInfo);
 typedef void (*WKPageUIClientCallback)(WKPageRef page, const void* clientInfo);
 typedef WKPageRef (*WKPageCreateNewPageCallback)(WKPageRef page, WKPageConfigurationRef configuration, WKNavigationActionRef navigationAction, WKWindowFeaturesRef windowFeatures, const void *clientInfo);
 typedef void (*WKPageRunBeforeUnloadConfirmPanelCallback)(WKPageRef page, WKStringRef message, WKFrameRef frame, WKPageRunBeforeUnloadConfirmPanelResultListenerRef listener, const void *clientInfo);
@@ -757,6 +758,7 @@ typedef struct WKPageUIClientV8 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
     
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 } WKPageUIClientV8;
@@ -845,6 +847,7 @@ typedef struct WKPageUIClientV9 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -936,6 +939,7 @@ typedef struct WKPageUIClientV10 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
     
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
     
@@ -1031,6 +1035,7 @@ typedef struct WKPageUIClientV11 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1129,6 +1134,7 @@ typedef struct WKPageUIClientV12 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
     
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
     
@@ -1230,6 +1236,7 @@ typedef struct WKPageUIClientV13 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1334,6 +1341,7 @@ typedef struct WKPageUIClientV14 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1441,6 +1449,7 @@ typedef struct WKPageUIClientV15 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1552,6 +1561,7 @@ typedef struct WKPageUIClientV16 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1666,6 +1676,7 @@ typedef struct WKPageUIClientV17 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1782,6 +1793,7 @@ typedef struct WKPageUIClientV18 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11703,6 +11703,11 @@ bool WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock() const
     return false;
 }
 
+void WebPageProxy::willAddDetailedMessageToConsole(const String& src, const String& level, uint64_t line, uint64_t col, const String& message, const String& url)
+{
+   fprintf(stderr, "sureshk WebPageProxy :: willAddDetailedMessageToConsole -> uiclint->willAddDetailedMessageToConsole \n");
+    m_uiClient->willAddDetailedMessageToConsole(*this, src, level, line, col, message, url);
+}
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1808,6 +1808,8 @@ public:
     void getApplicationManifest(CompletionHandler<void(const std::optional<WebCore::ApplicationManifest>&)>&&);
 #endif
 
+    void willAddDetailedMessageToConsole(const String& src, const String& level, uint64_t line, uint64_t col, const String& message, const String& url);
+
     WebPreferencesStore preferencesStore() const;
 
     void setDefersLoadingForTesting(bool);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -100,7 +100,8 @@ messages -> WebPageProxy {
     ShowDateTimePicker(struct WebCore::DateTimeChooserParameters params);
     EndDateTimePicker();
 #endif
-
+    
+    WillAddDetailedMessageToConsole(String src, String level, uint64_t line, uint64_t column, String message, String url);
     # Policy messages
     DecidePolicyForResponse(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::PolicyCheckIdentifier policyCheckIdentifier, uint64_t navigationID, WebCore::ResourceResponse response, WebCore::ResourceRequest request, bool canShowMIMEType, String downloadAttribute, bool wasAllowedByInjectedBundle, uint64_t listenerID, WebKit::UserData userData)
     DecidePolicyForNavigationActionAsync(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::PolicyCheckIdentifier policyCheckIdentifier, uint64_t navigationID, struct WebKit::NavigationActionData navigationActionData, struct WebKit::FrameInfoData originatingFrameInfoData, std::optional<WebKit::WebPageProxyIdentifier> originatingPageID, WebCore::ResourceRequest originalRequest, WebCore::ResourceRequest request, IPC::FormDataReference requestBody, WebCore::ResourceResponse redirectResponse, WebKit::UserData userData, uint64_t listenerID)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageUIClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageUIClient.h
@@ -35,6 +35,30 @@ enum {
 };
 typedef uint32_t WKBundlePageUIElementVisibility;
 
+enum {
+    WKConsoleMessageSourceXML,
+    WKConsoleMessageSourceJS,
+    WKConsoleMessageSourceNetwork,
+    WKConsoleMessageSourceConsoleAPI,
+    WKConsoleMessageSourceStorage,
+    WKConsoleMessageSourceAppCache,
+    WKConsoleMessageSourceRendering,
+    WKConsoleMessageSourceCSS,
+    WKConsoleMessageSourceSecurity,
+    WKConsoleMessageSourceContentBlocker,
+    WKConsoleMessageSourceOther
+};
+typedef uint32_t WKConsoleMessageSource;
+
+enum {
+    WKConsoleMessageLevelLog,
+    WKConsoleMessageLevelWarning,
+    WKConsoleMessageLevelError,
+    WKConsoleMessageLevelDebug,
+    WKConsoleMessageLevelInfo,
+};
+typedef uint32_t WKConsoleMessageLevel;
+
 
 typedef void (*WKBundlePageWillAddMessageToConsoleCallback)(WKBundlePageRef page, WKStringRef message, uint32_t lineNumber, const void *clientInfo);
 typedef void (*WKBundlePageWillSetStatusbarTextCallback)(WKBundlePageRef page, WKStringRef statusbarText, const void *clientInfo);
@@ -56,6 +80,7 @@ typedef WKStringRef (*WKBundlePagePlugInCreateExtraScriptCallback)(const void *c
 typedef void (*WKBundlePageDidClickAutoFillButtonCallback)(WKBundlePageRef page, WKBundleNodeHandleRef inputElement, WKTypeRef* userData, const void *clientInfo);
 typedef void (*WKBundlePageDidResignInputElementStrongPasswordAppearance)(WKBundlePageRef page, WKBundleNodeHandleRef inputElement, WKTypeRef* userData, const void *clientInfo);
 typedef void (*WKBundlePageWillAddMessageWithDetailsToConsoleCallback)(WKBundlePageRef page, WKStringRef message, WKArrayRef messageArguments, uint32_t lineNumber, uint32_t columnNumber, WKStringRef sourceID, const void *clientInfo);
+typedef void (*WKBundlePageWillAddDetailedMessageToConsoleCallback)(WKBundlePageRef page, WKStringRef source, WKStringRef level, uint32_t lineNumber, uint32_t columnNumber, WKStringRef message, WKStringRef url, const void *clientInfo);
 
 typedef struct WKBundlePageUIClientBase {
     int                                                                 version;
@@ -210,6 +235,7 @@ typedef struct WKBundlePageUIClientV4 {
 
     // Version 4.
     WKBundlePageDidResignInputElementStrongPasswordAppearance           didResignInputElementStrongPasswordAppearance;
+    WKBundlePageWillAddDetailedMessageToConsoleCallback                 willAddDetailedMessageToConsole;
 } WKBundlePageUIClientV4;
 
 typedef struct WKBundlePageUIClientV5 {
@@ -253,4 +279,5 @@ typedef struct WKBundlePageUIClientV5 {
 
     // Version 5.
     WKBundlePageWillAddMessageWithDetailsToConsoleCallback              willAddMessageWithDetailsToConsole;
+    WKBundlePageWillAddDetailedMessageToConsoleCallback                 willAddDetailedMessageToConsole;
 } WKBundlePageUIClientV5;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -290,6 +290,7 @@ private:
     bool m_frameHasCustomContentProvider { false };
     bool m_frameCameFromBackForwardCache { false };
     bool m_useIconLoadingClient { false };
+    bool m_sendRenderingAfterFailedLoad { false };
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
     std::optional<FrameSpecificStorageAccessIdentifier> m_frameSpecificStorageAccessIdentifier;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -277,6 +277,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/text/TextStream.h>
+#include <WebCore/CairoUtilities.h>
 
 #if ENABLE(APP_HIGHLIGHTS)
 #include <WebCore/AppHighlightStorage.h>
@@ -1770,6 +1771,7 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
 
     ASSERT(!m_pendingNavigationID);
     ASSERT(!m_pendingWebsitePolicies);
+    WebCore::resetRenderingStartedFlag();
 }
 
 // LoadRequestWaitingForProcessLaunch should never be sent to the WebProcess. It must always be converted to a LoadRequest message.


### PR DESCRIPTION
In below issues we added debug logs for WPE 2.22. We want to have them also for 2.38 (mostly only for debug build):
1.
[ARRISAPOL-2961](https://jira.lgi.io/browse/ARRISAPOL-2961) : libsoup logs are not enabled with network logs
File Modified:
WPE 2.22: [Source/WebCore/platform/network/soup/SoupNetworkSession.cpp](https://github.com/LibertyGlobal/WPEWebKit/pull/333)
WPE2.38: Source/WebCore/platform/network/soup/SoupNetworkSession.cpp

2.
[ONEM-26575](https://jira.lgi.io/browse/ARRISEOS-42731) : debug logs to responsive mechanism
Already available for WPE 2.22 and WPE 2.38

3.
[ARRISEOS-41626](https://jira.lgi.io/browse/ARRISEOS-41626) : JS logs not seen in journal
WPE 2.22: https://github.com/LibertyGlobal/WPEWebKit/pull/135
WPE 2.38:
        modified:   Source/WebKit/UIProcess/API/APIUIClient.h
	modified:   Source/WebKit/UIProcess/API/C/WKPage.cpp
	modified:   Source/WebKit/UIProcess/API/C/WKPageUIClient.h
	modified:   Source/WebKit/UIProcess/WebPageProxy.cpp
	modified:   Source/WebKit/UIProcess/WebPageProxy.h
	modified:   Source/WebKit/UIProcess/WebPageProxy.messages.in
	modified:   Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageUIClient.h
	modified:   Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
	modified:   Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
	modified:   Source/WebKit/WebProcess/WebPage/WebPage.cpp

4.
[ONEM-25729](https://jira.lgi.io/browse/ONEM-25729) : rendering started logs
WPE 2.22: https://github.com/LibertyGlobal/WPEWebKit/pull/129
WPE 2.38:
Almost Same file modified but not exactly at same place.

5.
[ARRISEOS-41563](https://jira.lgi.io/browse/ARRISEOS-41563) : memory peak logs
WPE 2.22:
Source/WTF/wtf/MemoryPressureHandler.cpp
WPE 2.38
Source/WTF/wtf/MemoryPressureHandler.cpp

6.
SCA fixes should also be added: [ARRISEOS-42565](https://jira.lgi.io/browse/ARRISEOS-42565)

