### PR TITLE
[ONEM-33064] Support only hardware decoders

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -307,7 +307,7 @@ public:
 
     static GRefPtr<GstElementFactory> GstDecoderFactory(const char *capsStr)
     {
-        return GStreamerRegistryScanner::singleton().isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, String::fromUTF8(capsStr), false).factory;
+        return GStreamerRegistryScanner::singleton().isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, String::fromUTF8(capsStr), true).factory;
     }
 
     bool HasGstDecoder()


### PR DESCRIPTION
Port of Comcast patch
https://code.rdkcentral.com/r/plugins/gitiles/collaboration/comcast-lgi/rdk/yocto_oe/layers/meta-rdk-ext/+/refs/heads/23Q4_sprint/recipes-extended/wpe-webkit/files/2.38/comcast-RDK-40634-Only-support-decoders-with-hw-support-for-webrtc.patch