### PR TITLE
[ONEM-32477] : WPE 2.38 - port debug logs -> RDK logger and others

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -284,9 +284,11 @@ void MemoryPressureHandler::measurementTimerFired()
 {
     size_t footprint = memoryFootprint();
     size_t footprintVideo = memoryFootprintVideo();
-#if PLATFORM(COCOA)
-    RELEASE_LOG(MemoryPressure, "Current memory footprint: %zu MB", footprint / MB);
-#endif
+
+    static size_t footprintPeak = 0;
+    if (footprintPeak < footprint)
+        footprintPeak = footprint;
+    RELEASE_LOG(MemoryPressure, "Current memory footprint: %zu MB, peak: %zu MB", footprint / MB, footprintPeak / MB);
     auto killThreshold = thresholdForMemoryKill(MemoryType::Normal);
     auto killThresholdVideo = thresholdForMemoryKill(MemoryType::Video);
     if ((killThreshold && footprint >= *killThreshold) || (killThresholdVideo && footprintVideo >= *killThresholdVideo)) {

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -157,7 +157,14 @@ SoupNetworkSession::~SoupNetworkSession() = default;
 void SoupNetworkSession::setupLogger()
 {
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
-    if (LogNetwork.state != WTFLogChannelState::On || soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_LOGGER))
+    if (
+#if ENABLE(RDK_LOGGER)
+        !rdk_dbg_enabled(RDK_LOG_CHANNEL(NETWORK), RDK_LOG_DEBUG)
+#else
+        LogNetwork.state != WTFLogChannelState::On
+#endif // ENABLE(RDK_LOGGER)
+         || soup_session_get_feature(m_soupSession.get(), SOUP_TYPE_LOGGER)
+    )
         return;
 
 #if USE(SOUP2)

--- a/Source/WebKit/Platform/IPC/Attachment.h
+++ b/Source/WebKit/Platform/IPC/Attachment.h
@@ -111,7 +111,7 @@ private:
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     UnixFileDescriptor m_fd;
-    size_t m_size;
+    size_t m_size { };
     CustomWriter m_customWriter;
 #elif OS(WINDOWS)
     HANDLE m_handle { INVALID_HANDLE_VALUE };

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -167,7 +167,7 @@ private:
     OptionSet<MessageFlags> m_messageFlags;
     MessageName m_messageName;
 
-    uint64_t m_destinationID;
+    uint64_t m_destinationID { };
 
 #if PLATFORM(MAC)
     ImportanceAssertion m_importanceAssertion;

--- a/Source/WebKit/Platform/Module.h
+++ b/Source/WebKit/Platform/Module.h
@@ -71,7 +71,7 @@ private:
 #if USE(CF)
     RetainPtr<CFBundleRef> m_bundle;
 #elif USE(GLIB)
-    GModule* m_handle;
+    GModule* m_handle = nullptr;;
 #endif
 };
 

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -56,7 +56,7 @@ struct LoadParameters {
     void platformEncode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool platformDecode(IPC::Decoder&, LoadParameters&);
 
-    uint64_t navigationID;
+    uint64_t navigationID { };
 
     WebCore::ResourceRequest request;
     SandboxExtension::Handle sandboxExtensionHandle;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -63,7 +63,7 @@ struct HTTPBody {
 
         // File.
         String filePath;
-        int64_t fileStart;
+        int64_t fileStart { };
         std::optional<int64_t> fileLength;
         std::optional<WallTime> expectedFileModificationTime;
 


### PR DESCRIPTION
1.
[ARRISAPOL-2961](https://jira.lgi.io/browse/ARRISAPOL-2961) : libsoup logs are not enabled with network logs
File Modified:
WPE 2.22: https://github.com/LibertyGlobal/WPEWebKit/pull/333
WPE2.38: Source/WebCore/platform/network/soup/SoupNetworkSession.cpp

2.
[ARRISEOS-41563](https://jira.lgi.io/browse/ARRISEOS-41563) : memory peak logs
WPE 2.22:
Source/WTF/wtf/MemoryPressureHandler.cpp
WPE 2.38
Source/WTF/wtf/MemoryPressureHandler.cpp
3.
SCA fixes should also be added: [ARRISEOS-42565](https://jira.lgi.io/browse/ARRISEOS-42565)