### PR TITLE
[ONEM-33064] Expose Host ICE candidates

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -353,9 +353,9 @@ ICECandidateFilteringEnabled:
     WebKitLegacy:
       default: true
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
 
 IOSFormControlRefreshEnabled:
   type: bool


### PR DESCRIPTION
By default, without access to capture devices, WebKit only exposes Server Reflexive and TURN ICE candidates. When access to capture devices is granted, WebKit will expose host ICE candidates.

LGI scenarios require usage of Host ICE candidates without capture device and within the same local network.

This is a port of Comcast patch:
https://code.rdkcentral.com/r/plugins/gitiles/collaboration/comcast-lgi/rdk/yocto_oe/layers/meta-rdk-ext/+/refs/heads/23Q4_sprint/recipes-extended/wpe-webkit/files/2.38/comcast-DELIA-60613-WebRTC-streaming-fails-with-test.patch
