### PR TITLE
[ONEM-32477]:WPE 2.38 - port debug logs->DetailsConsoleMessage

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -231,6 +231,8 @@ public:
     virtual void startXRSession(WebKit::WebPageProxy&, CompletionHandler<void(RetainPtr<id>)>&& completionHandler) { completionHandler(nil); }
     virtual void endXRSession(WebKit::WebPageProxy&) { }
 #endif
+
+    virtual void willAddDetailedMessageToConsole( WebKit::WebPageProxy&, const WTF::String& source, const WTF::String& level, uint64_t line, uint64_t col, const WTF::String& message, const WTF::String& url) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2068,6 +2068,18 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             m_client.didResignInputElementStrongPasswordAppearance(toAPI(&page), toAPI(userInfo), m_client.base.clientInfo);
         }
 
+	void willAddDetailedMessageToConsole(WebPageProxy& page, const String& source, const String& level,
+            uint64_t line, uint64_t column, const String& message, const String& url) final
+        {
+	    fprintf(stderr, "SK:WKPage.cpp: *** willAddDetailedMessageToConsole->m_client:message:%s \n", message.utf8().data());
+            if (!m_client.willAddDetailedMessageToConsole)
+                return;
+            
+	    fprintf(stderr, "SK:WKPage.cpp: willAddDetailedMessageToConsole->m_client:message:%s \n", message.utf8().data());
+	    m_client.willAddDetailedMessageToConsole(toAPI(page), toAPI(source.impl()), toAPI(level.impl()),
+                    line, column, toAPI(message.impl()), toAPI(url.impl()), m_client.base.clientInfo);
+        }
+
 #if ENABLE(POINTER_LOCK)
         void requestPointerLock(WebPageProxy* page) final
         {

--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -154,6 +154,7 @@ typedef void (*WKPageRunJavaScriptAlertCallback_deprecatedForUseWithV5)(WKPageRe
 typedef bool (*WKPageRunJavaScriptConfirmCallback_deprecatedForUseWithV5)(WKPageRef page, WKStringRef message, WKFrameRef frame, WKSecurityOriginRef securityOrigin, const void *clientInfo);
 typedef WKStringRef (*WKPageRunJavaScriptPromptCallback_deprecatedForUseWithV5)(WKPageRef page, WKStringRef message, WKStringRef defaultValue, WKFrameRef frame, WKSecurityOriginRef securityOrigin, const void *clientInfo);
 typedef bool (*WKPageRunBeforeUnloadConfirmPanelCallback_deprecatedForUseWithV6)(WKPageRef page, WKStringRef message, WKFrameRef frame, const void *clientInfo);
+typedef void (*WKPageWillAddDetailedMessageToConsoleCallback)(WKPageRef page, WKStringRef source, WKStringRef level, uint64_t line, uint64_t column, WKStringRef message, WKStringRef url, const void* clientInfo);
 
 typedef struct WKPageUIClientBase {
     int                                                                 version;
@@ -757,6 +758,7 @@ typedef struct WKPageUIClientV8 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
     
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 } WKPageUIClientV8;
@@ -845,6 +847,7 @@ typedef struct WKPageUIClientV9 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -936,6 +939,7 @@ typedef struct WKPageUIClientV10 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
     
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
     
@@ -1031,6 +1035,7 @@ typedef struct WKPageUIClientV11 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1129,6 +1134,7 @@ typedef struct WKPageUIClientV12 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
     
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
     
@@ -1230,6 +1236,7 @@ typedef struct WKPageUIClientV13 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1334,6 +1341,7 @@ typedef struct WKPageUIClientV14 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1441,6 +1449,7 @@ typedef struct WKPageUIClientV15 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1552,6 +1561,7 @@ typedef struct WKPageUIClientV16 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1666,6 +1676,7 @@ typedef struct WKPageUIClientV17 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 
@@ -1782,6 +1793,7 @@ typedef struct WKPageUIClientV18 {
     WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
 
     // Version 8.
+    WKPageWillAddDetailedMessageToConsoleCallback                       willAddDetailedMessageToConsole;
     WKRequestPointerLockCallback                                        requestPointerLock;
     WKDidLosePointerLockCallback                                        didLosePointerLock;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11703,6 +11703,12 @@ bool WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock() const
     return false;
 }
 
+void WebPageProxy::willAddDetailedMessageToConsole(const String& src, const String& level, uint64_t line, uint64_t col, const String& message, const String& url)
+{
+    fprintf(stderr, "SK: WebPageProxy::willAddDetailedMessageToConsole ->m_ uiClient->will message:%s\n", message.utf8().data());
+    m_uiClient->willAddDetailedMessageToConsole(*this, src, level, line, col, message, url);
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1808,6 +1808,8 @@ public:
     void getApplicationManifest(CompletionHandler<void(const std::optional<WebCore::ApplicationManifest>&)>&&);
 #endif
 
+    void willAddDetailedMessageToConsole(const String& src, const String& level, uint64_t line, uint64_t col, const String& message, const String& url);
+
     WebPreferencesStore preferencesStore() const;
 
     void setDefersLoadingForTesting(bool);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -101,6 +101,8 @@ messages -> WebPageProxy {
     EndDateTimePicker();
 #endif
 
+    WillAddDetailedMessageToConsole(String src, String level, uint64_t line, uint64_t column, String message, String url);
+
     # Policy messages
     DecidePolicyForResponse(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::PolicyCheckIdentifier policyCheckIdentifier, uint64_t navigationID, WebCore::ResourceResponse response, WebCore::ResourceRequest request, bool canShowMIMEType, String downloadAttribute, bool wasAllowedByInjectedBundle, uint64_t listenerID, WebKit::UserData userData)
     DecidePolicyForNavigationActionAsync(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::PolicyCheckIdentifier policyCheckIdentifier, uint64_t navigationID, struct WebKit::NavigationActionData navigationActionData, struct WebKit::FrameInfoData originatingFrameInfoData, std::optional<WebKit::WebPageProxyIdentifier> originatingPageID, WebCore::ResourceRequest originalRequest, WebCore::ResourceRequest request, IPC::FormDataReference requestBody, WebCore::ResourceResponse redirectResponse, WebKit::UserData userData, uint64_t listenerID)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp
@@ -46,12 +46,16 @@ InjectedBundlePageUIClient::InjectedBundlePageUIClient(const WKBundlePageUIClien
 
 void InjectedBundlePageUIClient::willAddMessageToConsole(WebPage* page, MessageSource, MessageLevel, const String& message, unsigned lineNumber, unsigned /*columnNumber*/, const String& /*sourceID*/)
 {
-    if (m_client.willAddMessageToConsole)
+    fprintf(stderr, "SK: InjectedBundlePageUIClient::willAddMessageToConsole  :messahe:%s\n", message.utf8().data());
+    if (m_client.willAddMessageToConsole) {
+	fprintf(stderr, "SK: InjectedBundlePageUIClient::willAddMessageToConsole->m_client.willAddMessageToConsole \n");
         m_client.willAddMessageToConsole(toAPI(page), toAPI(message.impl()), lineNumber, m_client.base.clientInfo);
+     }
 }
 
 void InjectedBundlePageUIClient::willAddMessageWithArgumentsToConsole(WebPage* page, MessageSource, MessageLevel, const String& message, Span<const String> messageArguments, unsigned lineNumber, unsigned columnNumber, const String& sourceID)
 {
+    fprintf(stderr, "SK: InjectedBundlePageUIClient::willAddMessageWithArgumentsToConsole \n");
     if (m_client.willAddMessageWithDetailsToConsole)
         m_client.willAddMessageWithDetailsToConsole(toAPI(page), toAPI(message.impl()), toAPI(&API::Array::createStringArray(messageArguments).leakRef()), lineNumber, columnNumber, toAPI(sourceID.impl()), m_client.base.clientInfo);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -411,6 +411,7 @@ void WebChromeClient::setResizable(bool resizable)
 void WebChromeClient::addMessageToConsole(MessageSource source, MessageLevel level, const String& message, unsigned lineNumber, unsigned columnNumber, const String& sourceID)
 {
     // Notify the bundle client.
+    fprintf(stderr, "\n WebChromeClient::addMessageToConsole->m_page.injectedBundleUIClient().willAddMessageToConsole: message:%s\n", message.utf8().data());
     m_page.injectedBundleUIClient().willAddMessageToConsole(&m_page, source, level, message, lineNumber, columnNumber, sourceID);
 }
 


### PR DESCRIPTION
[ONEM-32477] WPE 2.38 - port debug logs

WPE-2.22
[ARRISEOS-41626](https://jira.lgi.io/browse/ARRISEOS-41626) : JS logs not seen in journal
WPE 2.22: https://github.com/LibertyGlobal/WPEWebKit/pull/135


WPE 2.38:
modified: Source/WebKit/UIProcess/API/APIUIClient.h
modified: Source/WebKit/UIProcess/API/C/WKPage.cpp
modified: Source/WebKit/UIProcess/API/C/WKPageUIClient.h
modified: Source/WebKit/UIProcess/WebPageProxy.cpp
modified: Source/WebKit/UIProcess/WebPageProxy.h
modified: Source/WebKit/UIProcess/WebPageProxy.messages.in
modified: Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
modified: Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
modified: Source/WebKit/WebProcess/WebPage/WebPage.cpp