### PR TITLE
[ONEM-31699] :WPE 2.38 - Smooth London radiostation starts to play after around 1 minutes in Radioline app

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -357,10 +357,6 @@ void MediaPlayerPrivateGStreamer::load(const String& urlString)
     m_areVolumeAndMuteInitialized = false;
     m_hasTaintedOrigin = std::nullopt;
 
-#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-    m_isShoutcastStreaming = false;
-#endif // PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-
     if (!m_isDelayingLoad)
         commitLoad();
 }
@@ -1881,12 +1877,6 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         }
 #endif
 
-#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-        if (currentState == GST_STATE_NULL && newState == GST_STATE_READY && g_strstr_len(GST_MESSAGE_SRC_NAME(message), 8, "icydemux")) {
-            m_isShoutcastStreaming = true;
-        }
-#endif // PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-
         if (!messageSourceIsPlaybin || m_isDelayingLoad)
             break;
 
@@ -2080,13 +2070,6 @@ void MediaPlayerPrivateGStreamer::processBufferingStats(GstMessage* message)
     gst_message_parse_buffering(message, &percentage);
 
     updateBufferingStatus(mode, percentage);
-
-#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-    if (m_isShoutcastStreaming) {
-        GstObject *queue2 = GST_MESSAGE_SRC(message);
-        tryReduceQueueSize(queue2);
-    }
-#endif // PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
 }
 
 void MediaPlayerPrivateGStreamer::updateMaxTimeLoaded(double percentage)
@@ -4544,22 +4527,6 @@ void MediaPlayerPrivateGStreamer::checkPlayingConsistency()
             m_didTryToRecoverPlayingState = false;
     }
 }
-
-#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-void MediaPlayerPrivateGStreamer::tryReduceQueueSize(GstObject* queue)
-{
-    guint max_size_bytes = 0;
-    g_object_get(queue, "max-size-bytes", &max_size_bytes, NULL);
-
-    // ARRISEOS-43118 : for some specific aac shoutcast streams mpegaudioparse plugin is not attached to pipeline and in consequence bitstream
-    // value cannot be correctly calculated. UriDecodeBin is setting queue size based on that bitstream value.
-    // Let's reduce for those specific audio streams queue size to reasonable size
-    if (max_size_bytes >= 2097152) {
-         GST_DEBUG("Hardcode queue max size\n");
-         g_object_set(queue, "max-size-bytes", 16000, NULL);
-    }
-}
-#endif // PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
 
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -552,10 +552,6 @@ private:
     void configureMediaStreamAudioTracks();
     void invalidateCachedPositionOnNextIteration() const;
 
-#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-    void tryReduceQueueSize(GstObject* queue);
-#endif // PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-
     Atomic<bool> m_isPlayerShuttingDown;
     GRefPtr<GstElement> m_textSink;
     GUniquePtr<GstStructure> m_mediaLocations;
@@ -670,10 +666,6 @@ private:
     // Specific to MediaStream playback.
     MediaTime m_startTime;
     MediaTime m_pausedTime;
-
-#if PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
-    bool m_isShoutcastStreaming = false;
-#endif // PLATFORM(BCM_NEXUS) || PLATFORM(BROADCOM)
 };
 
 }


### PR DESCRIPTION
[ONEM-31699] :WPE 2.38 - Smooth London radiostation starts to play after around 1 minutes in Radioline app:
Reverting this changes since on latest build, without this change also ONEM-31699 is not reproducible.