### PR TITLE
[ARRISAPP-867] Disable preserve pitch when native audio is enabled

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1275,7 +1275,11 @@ double MediaPlayerPrivateGStreamer::rate() const
 
 void MediaPlayerPrivateGStreamer::setPreservesPitch(bool preservesPitch)
 {
+#if ENABLE(NATIVE_AUDIO)
+    UNUSED_PARAM(preservesPitch);
+#else
     m_preservesPitch = preservesPitch;
+#endif
 }
 
 std::unique_ptr<PlatformTimeRanges> MediaPlayerPrivateGStreamer::buffered() const


### PR DESCRIPTION
Pitch preserving adds scaletempo gstreamer element to the pipeline,
which doesn't accept "audio/x-raw format: brcm" caps. This causes
pipeline to have caps not fully negotiated which accidently broke video
playback on all progresive streams when error reporting was improved in
gstreamer.

scaletempo element was after audfilter in the pipeline, so any potential
changes to the audio buffers it could do were not relevant anyway.