### PR TITLE
[ONEM-33162]: WPE 2.38 - port debug logs for JS logs not seen in Journal

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -282,6 +282,10 @@ void WebFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, ResourceL
         return;
 
     webPage->injectedBundleResourceLoadClient().didReceiveResponseForResource(*webPage, m_frame, identifier, response);
+    if (response.httpStatusCode() >= 400) {
+        String message = "Failed to load resource: the server responded with a status of " + String::number(response.httpStatusCode()) + " (" + response.httpStatusText() + ')';
+        LOG(Loading,"dispatchDidReceiveResponse->message:%s", message.utf8().data());
+    }
 }
 
 void WebFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier identifier, int dataLength)
@@ -321,6 +325,8 @@ void WebFrameLoaderClient::dispatchDidFailLoading(DocumentLoader*, ResourceLoade
 
     webPage->injectedBundleResourceLoadClient().didFailLoadForResource(*webPage, m_frame, identifier, error);
     webPage->removeResourceRequest(identifier);
+    
+    LOG(Loading,"dispatchedDidFailLoading: isTimeout=%d, isCancellation=%d, isAccessControl=%d, errorCode=%d description:%s", error.isTimeout(), error.isCancellation(), error.isAccessControl(), error.errorCode(), error.localizedDescription().utf8().data());
 }
 
 bool WebFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int /*length*/)
@@ -648,6 +654,9 @@ void WebFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)
 
     // ARRISAPOL-1754: Skip sending renderingStarted event for failed URLs
     m_sendRenderingAfterFailedLoad = true;
+
+    LOG(Loading,"dispatchDidFailLoad: isTimeout= %d, isCancellation= %d, isAccessControl= %d, errorCode= %d description: %s", error.isTimeout(), error.isCancellation(), error.isAccessControl(), error.errorCode(), error.localizedDescription().utf8().data());
+    
     WebCore::setRenderingStartedFlag();
 }
 


### PR DESCRIPTION
Description:
Some JS errors are not seen in journal.

Severity:
Medium

Replication path/steps:
Trigger JS error from web inspector:

var xhr = new XMLHttpRequest();
xhr.onreadystatechange = function() {
    if (this.readyState == 1) {
       console.log('opened state')
    }
    if (this.readyState == 2) {
        console.log('headers received state')
    }
    if (this.readyState == 3) {
        console.log('loading state')
    }
    if (this.readyState == 4 && this.status == 200) {
         console.log('done state');
         document.getElementById("demo").innerHTML =
         this.responseText;
    }
};

xhr.open("GET", "http://localhost:8000/info.txt", true);
xhr.send();
After about 60 sec, error is seen in web inspector: "Failed to load resource: Could not connect: Socket I/O timed out"

Actual results:
Error is not seen in journal file

Expected results:
Error must be seen in journal file

Frequency (percentage):
100%

=============================================================================================
Few more use case:
case1:
open this URL on the box: http://mvt.onemw.net/test-materials/sandbox/js_errors.html
Expected logs:
should include stack trace

case2;
in the web inspector console execute this script: 
var xhr = new XMLHttpRequest(); xhr.open('GET', 'https://example.com', true); xhr.send();
Expected logs:
XMLHttpRequest cannot load https://example.com 

Case3:
(function () {
  if (typeof navigator.requestMediaKeySystemAccess === "function") {
    const keySystems = ["org.w3.clearkey"];

    keySystems.forEach(async (keySystem) => {
      try {
        const keySystemConfig = {
          initDataTypes: ["cenc"],
          videoCapabilities: [
            { contentType: 'video/mp4; codecs="avc1.42E01E"' },
          ],
        };

        const keySystemAccess = await navigator.requestMediaKeySystemAccess(
          keySystem,
          [keySystemConfig]
        );
        console.log(keySystem, "is supported.");
      } catch (error) {
        console.log(keySystem, "is NOT supported.");
      }
    });
  } else {
    console.log("EME API is not supported in this browser.");
  }
})();
Expected logs:
org.w3.clearkey is not supported 