### PR TITLE
[ARRISAPP-880] Add runtime check in MSE path for Dolby Vision

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -962,7 +962,7 @@ void MediaPlayerPrivateGStreamerMSE::trackDetected(RefPtr<AppendPipeline> append
         m_playbackPipeline->reattachTrack(appendPipeline->sourceBufferPrivate(), newTrack, caps);
 }
 
-#if PLATFORM(BCM_NEXUS) && ENABLE(DV)
+#if PLATFORM(BCM_NEXUS) && ENABLE(DOLBY_VISION)
 bool isDolbyVisionSupportedOnDevice()
 {
     // hdmi_output file contains current information about available HDR on TV side
@@ -1118,7 +1118,7 @@ bool MediaPlayerPrivateGStreamerMSE::supportsCodec(String codec)
         }
     }
 
-#if PLATFORM(BCM_NEXUS) && ENABLE(DV)
+#if PLATFORM(BCM_NEXUS) && ENABLE(DOLBY_VISION)
     if (checkRuntimeCodecSupport(codec))
         return true;
 #endif

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -170,6 +170,10 @@ if ( ENABLE_ENCRYPTED_MEDIA )
     endif()
 endif()
 
+if (ENABLE_DV)
+    add_definitions(-DENABLE_DV=1)
+endif()
+
 if (ENABLE_VP9_HDR)
   add_definitions(-DENABLE_VP9_HDR=1)
 endif()

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -170,8 +170,8 @@ if ( ENABLE_ENCRYPTED_MEDIA )
     endif()
 endif()
 
-if (ENABLE_DV)
-    add_definitions(-DENABLE_DV=1)
+if (ENABLE_DOLBY_VISION)
+    add_definitions(-DENABLE_DOLBY_VISION=1)
 endif()
 
 if (ENABLE_VP9_HDR)


### PR DESCRIPTION
isTypeSupported() now checks combined capabilities of STB and TV. 
Dolby Vision is only supported on Apollo v1+.
Fix is required for AppleTV+, which want to play content with Dolby Vision.

Support for TV disconnection is covered, which may introduce (very unlikely) some performance regression when many isTypeSupported queries with false result will be sent by app simultaneously.