### PR TITLE
[ARRISAPP-907] : Revert "[ARRISEOS-45318] Check codec type for canPlayType API"

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2919,15 +2919,14 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
     if (parameters.type.containerType() == "video/x-flv")
         return result;
 
-    bool hasCodec = !parameters.type.codecs().isEmpty();
     // spec says we should not return "probably" if the codecs string is empty
     if (mimeTypeSet().contains(parameters.type.containerType()))
-        result = !hasCodec ? MediaPlayer::MayBeSupported : MediaPlayer::IsSupported;
+        result = parameters.type.codecs().isEmpty() ? MediaPlayer::MayBeSupported : MediaPlayer::IsSupported;
 
 #if PLATFORM(BROADCOM)
-    if (result != MediaPlayer::IsNotSupported && hasCodec) {
+    if (result != MediaPlayer::IsNotSupported && AtomicString("video/webm") == parameters.type.containerType()) {
         Vector<String> codecs = parameters.type.codecs();
-        if (!MediaPlayerPrivateGStreamerMSE::supportsAllCodecs(codecs))
+        if (codecs.isEmpty() || !MediaPlayerPrivateGStreamerMSE::supportsAllCodecs(codecs))
             result = MediaPlayer::IsNotSupported;
     }
 #endif


### PR DESCRIPTION
After DolbyVision verification, it was stated that without switching to Dolby Vision Auto mode, sometimes during playback start we will get DRM errors, which will block playout in Apple TV+ app.