### PR TITLE
[ONEM-33645]: Setting PlaybackRate=0 does not pause video in WPE2.38

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -647,6 +647,12 @@ void MediaPlayerPrivateGStreamer::setRate(float rate)
             m_playbackRatePausedState = PlaybackRatePausedState::RatePaused;
             updateStates();
         }
+        if (m_currentState == GST_STATE_PLAYING && m_playbackRatePausedState != PlaybackRatePausedState::RatePaused) {
+            GST_INFO_OBJECT(pipeline(), "Pausing stream because of zero playback rate in setRate");
+            m_playbackRatePausedState = PlaybackRatePausedState::RatePaused;
+            changePipelineState(GST_STATE_PAUSED);
+            updatePlaybackRate();
+        }
         return;
     } else if (m_playbackRatePausedState == PlaybackRatePausedState::RatePaused) {
         m_playbackRatePausedState = PlaybackRatePausedState::ShouldMoveToPlaying;
@@ -659,6 +665,11 @@ void MediaPlayerPrivateGStreamer::setRate(float rate)
         || (pending == GST_STATE_PAUSED))
         return;
 
+    if (m_currentState == GST_STATE_PAUSED && m_playbackRate && m_playbackRatePausedState != PlaybackRatePausedState::Playing) {
+        m_playbackRatePausedState = PlaybackRatePausedState::Playing;
+        GST_INFO_OBJECT(pipeline(), "[Buffering] Restarting playback (because of resuming from zero playback rate) in setRate");
+        changePipelineState(GST_STATE_PLAYING);
+    }
     updatePlaybackRate();
 }
 


### PR DESCRIPTION
Description:
Setting PlaybackRate=0 in the web inspector does not pause the video.
Works fine for WPE 2.22 Apollo v1+ and other platforms. 
Additional info: you can set playbackRate=0.01 and video looks like paused, but playbackRate=0 is not changing playback rate at all.

How to reproduce:
- open France24 app
- play video from 'latest bulletins' (not live)
- go to web inspector console
- execute in the web inspector console: document.getElementsByTagName('video')[0].playbackRate=0

Actual result:
Nothing changed on the playing content

Expected result:
Video should be paused

SW version:
VIP7002W-wpe-dbg-06.03-000-aa-AL-20231204210000-un000


Note: Mostly playback rate is handle by gstreamer level but playback rate is zero is not handle by them so it should be handle at webkit level. So, we are handling setRate() in webkit code.