### PR TITLE
ONEM-32599: Enable ASYNC for brcmaudiosink when playbin2 is used

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2302,15 +2302,9 @@ void MediaPlayerPrivateGStreamer::configureElementPlatformQuirks(GstElement* ele
 #endif
 
 #if PLATFORM(BROADCOM)
-    if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiosink")) {
-        const char* usePlaybin3 = g_getenv("WEBKIT_GST_USE_PLAYBIN3");
-        if (usePlaybin3 && !strcmp(usePlaybin3, "1")) {
-            GST_INFO_OBJECT(pipeline(), "Enable async mode for brcmaduiosink");
-            g_object_set(G_OBJECT(element), "async", TRUE, nullptr);
-        } else {
-            GST_INFO_OBJECT(pipeline(), "Skip enabling async mode for brcmaduiosink");
-        }
-    } else if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiodecoder")) {
+    if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiosink"))
+        g_object_set(G_OBJECT(element), "async", TRUE, nullptr);
+    else if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiodecoder")) {
         if (m_isLiveStream.value_or(false)) {
             // Limit BCM audio decoder buffering to 1sec so live progressive playback can start faster.
             g_object_set(G_OBJECT(element), "limit_buffering_ms", 1000, nullptr);


### PR DESCRIPTION
Revert "ONEM-31886: Disable ASYNC for brcmaudiosink when playbin2 is used"

This reverts commit 75ccf5f91cf643f57d0fb185ebfea3f145910e40.
