### PR TITLE
ONEM-32068: WPE 2.38 - Black blink before background image is loading in oneplus app

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1142,11 +1142,11 @@ LargeImageAsyncDecodingEnabled:
   type: bool
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
 
 LayoutFallbackWidth:
   type: uint32_t


### PR DESCRIPTION
Black blink issue is not seen when this LargeImageAsyncDecodingEnabled is disabled.