### PR TITLE
ONEM-32068: WPE 2.38 - Black blink before background image is loading in oneplus app

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1142,11 +1142,11 @@ LargeImageAsyncDecodingEnabled:
   type: bool
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
 
 LayoutFallbackWidth:
   type: uint32_t


### PR DESCRIPTION
The black blink is not seen after the change suggested in below ticket

https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1207

