### PR TITLE
ONEM-34228: WPE-2.38: 23Q4 TV France is showing CS2400 error while trying to open

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -808,16 +808,20 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush, GstCl
     } else {
         // In the case of non-seeking flushes we don't reset the timeline, so instead we need to increase the `base` field
         // by however running time we're starting after the flush.
-        GstClockTime pipelineStreamTime = time;
-        if (GST_CLOCK_TIME_IS_VALID(pipelineStreamTime)) {
-            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
-            // We need to increase the base by the running time accumulated during the previous segment.
-            GstClockTime pipelineRunningTime = gst_segment_to_running_time(&streamingMembers->segment, GST_FORMAT_TIME, pipelineStreamTime);
-            if ((GST_CLOCK_TIME_IS_VALID(pipelineRunningTime))) {
-                GST_DEBUG_OBJECT(stream->source, "Resetting segment to current pipeline running time (%" GST_TIME_FORMAT " and stream time (%" GST_TIME_FORMAT " = %s)",
-                    GST_TIME_ARGS(pipelineRunningTime), GST_TIME_ARGS(pipelineStreamTime), GST_TIME_ARGS(pipelineStreamTime));
-                streamingMembers->segment.base = pipelineRunningTime;
-                streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
+	MediaPlayerPrivateGStreamerMSE* player = webKitMediaSrcPlayer(stream->source);
+        if (player) {
+            MediaTime streamTime = player->currentMediaTime();
+            GstClockTime pipelineStreamTime = time;
+            if (GST_CLOCK_TIME_IS_VALID(pipelineStreamTime)) {
+                DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+                // We need to increase the base by the running time accumulated during the previous segment.
+                GstClockTime pipelineRunningTime = gst_segment_to_running_time(&streamingMembers->segment, GST_FORMAT_TIME, pipelineStreamTime);
+                if ((GST_CLOCK_TIME_IS_VALID(pipelineRunningTime))) {
+                    GST_DEBUG_OBJECT(stream->source, "Resetting segment to current pipeline running time (%" GST_TIME_FORMAT " and stream time (%" GST_TIME_FORMAT " = %s)",
+                        GST_TIME_ARGS(pipelineRunningTime), GST_TIME_ARGS(pipelineStreamTime), streamTime.toString().ascii().data());
+                    streamingMembers->segment.base = pipelineRunningTime;
+                    streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
+                }
             }
         }
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -808,7 +808,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush, GstCl
     } else {
         // In the case of non-seeking flushes we don't reset the timeline, so instead we need to increase the `base` field
         // by however running time we're starting after the flush.
-	MediaPlayerPrivateGStreamerMSE* player = webKitMediaSrcPlayer(stream->source);
+	    MediaPlayerPrivateGStreamerMSE* player = webKitMediaSrcPlayer(stream->source);
         if (player) {
             MediaTime streamTime = player->currentMediaTime();
             GstClockTime pipelineStreamTime = time;


### PR DESCRIPTION
ONEM-34228: WPE-2.38: 23Q4 TV France is showing CS2400 error while trying to open

Issue was due to integer param passed to gstreamer API resulting in crash.
Issue happened up when migrating 23Q3 patches to wpe upstream as seen in below reference
https://github.com/LibertyGlobal/WPEWebKit/commit/feabf44027cc1216e3a3065460e3573b11e1f56d#diff-d0ebf2f17b1b12d3f4e2c239ae4b39a02f001eed8fde5438642338c58b8144a6R812