### PR TITLE
ARRISAPOL-3427: swap FATAL to LOG_ERROR for RELEASE_LOG_FAULT macro

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -657,7 +657,7 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #define PRIVATE_LOG_STRING "s"
 #define RELEASE_LOG(channel, ...) LOG(channel, __VA_ARGS__)
 #define RELEASE_LOG_ERROR(channel, ...) LOG_ERROR(__VA_ARGS__)
-#define RELEASE_LOG_FAULT(channel, ...) FATAL(__VA_ARGS__)
+#define RELEASE_LOG_FAULT(channel, ...) LOG_ERROR(__VA_ARGS__)
 #define RELEASE_LOG_INFO(channel, ...) LOG_WITH_LEVEL(channel, 3, __VA_ARGS__)
 
 #define RELEASE_LOG_WITH_LEVEL(channel, logLevel, ...)  LOG_WITH_LEVEL(channel, logLevel, ...)


### PR DESCRIPTION
After code review there are 5 implementation of RELEASE_LOG_FAULT and only the one introduced by us (RDK_LOGGER case) causes abort crash at the end. Changed to LOG_ERROR, no abort, no crash.