### PR TITLE
ARRISEOS-45736: Increase the time granularity

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4164,7 +4164,7 @@ void HTMLMediaElement::scanTimerFired()
 
 // The spec says to fire periodic timeupdate events (those sent while playing) every
 // "15 to 250ms", we choose the slowest frequency
-static const Seconds maxTimeupdateEventFrequency { 250_ms };
+static const Seconds maxTimeupdateEventFrequency { 200_ms };
 
 void HTMLMediaElement::startPlaybackProgressTimer()
 {
@@ -4211,8 +4211,8 @@ void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
     MonotonicTime now = MonotonicTime::now();
     Seconds timedelta = now - m_clockTimeAtLastUpdateEvent;
 
-    // throttle the periodic events
-    if (periodicEvent && timedelta < maxTimeupdateEventFrequency)
+    // Throttle the periodic events, but leave some room for timers that run slightly faster than expected.
+    if (periodicEvent && timedelta < (maxTimeupdateEventFrequency - 50_ms))
         return;
 
     // Some media engines make multiple "time changed" callbacks at the same time, but we only want one


### PR DESCRIPTION
This fixes YTB MSE Progressive Tests 29, 30, 32, 33 (granularity) by increasing the time granularity to better values (200ms on average, the spec allows a range from 15 to 250ms).