### PR TITLE
[ONEM-34706] Refactor rdkservices WebkitBrowser plugin code related to setting up client certificates required for mTLS

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -278,6 +278,7 @@ public:
     bool privateClickMeasurementEnabled() const;
     void setPrivateClickMeasurementDebugMode(PAL::SessionID, bool);
 
+    void preconnectToWithCert(PAL::SessionID, WebPageProxyIdentifier, WebCore::PageIdentifier, const URL&, const String&, const String&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>, LastNavigationWasAppInitiated);
     void preconnectTo(PAL::SessionID, WebPageProxyIdentifier, WebCore::PageIdentifier, const URL&, const String&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>, LastNavigationWasAppInitiated);
 
     void setSessionIsControlledByAutomation(PAL::SessionID, bool);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -75,6 +75,7 @@ messages -> NetworkProcess LegacyReceiver {
     PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> ()
     ProcessDidResume(bool forForegroundActivity)
 
+    PreconnectToWithCert(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, URL url, String userAgent, String userCertConf, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, enum:bool WebKit::LastNavigationWasAppInitiated lastNavigationWasAppInitiated);
     PreconnectTo(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, URL url, String userAgent, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, enum:bool WebKit::LastNavigationWasAppInitiated lastNavigationWasAppInitiated);
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3203,7 +3203,28 @@ void webkit_web_view_load_uri(WebKitWebView* webView, const gchar* uri)
 }
 
 /**
- * webkit_web_view_load_html:
+ * webkit_web_view_load_uri_and_cert:
+ * @web_view: a #WebKitWebView
+ * @uri: an URI string
+ * @cert_contents: an certificate data as string
+ *
+ * Requests loading of the specified URI string including new certificate data
+ *
+ * You can monitor the load operation by connecting to
+ * #WebKitWebView::load-changed signal.
+ */
+void webkit_web_view_load_uri_and_cert(WebKitWebView* webView, const gchar* uri, const gchar* cert_contents)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+    g_return_if_fail(uri);
+    g_return_if_fail(cert_contents);
+
+    auto userCertConf = API::String::create(String::fromUTF8(cert_contents));
+    getPage(webView).loadRequestAndCert(URL({ }, String::fromUTF8(uri)) , userCertConf.ptr());
+}
+
+/**
+ * webkit_web_view_load_html:,
  * @web_view: a #WebKitWebView
  * @content: The HTML string to load
  * @base_uri: (allow-none): The base URI for relative locations or %NULL

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
@@ -348,6 +348,11 @@ webkit_web_view_load_uri                             (WebKitWebView             
                                                       const gchar               *uri);
 
 WEBKIT_API void
+webkit_web_view_load_uri_and_cert                    (WebKitWebView             *webView,
+                                                      const gchar               *uri,
+                                                      const gchar               *cert_contents);
+
+WEBKIT_API void
 webkit_web_view_load_html                            (WebKitWebView             *web_view,
                                                       const gchar               *content,
                                                       const gchar               *base_uri);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1623,6 +1623,17 @@ void NetworkProcessProxy::createSymLinkForFileUpgrade(const String& indexedDatab
         FileSystem::createSymbolicLink(indexedDatabaseDirectory, oldVersionDirectory);
 }
 
+void NetworkProcessProxy::preconnectToWithCert(PAL::SessionID sessionID, WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, const URL& url, const String& userAgent, const String& userCertConf, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
+{
+    if (!url.isValid() || !url.protocolIsInHTTPFamily())
+        return;
+    if (userCertConf.isEmpty()) {
+        send(Messages::NetworkProcess::PreconnectTo(sessionID, webPageProxyID, webPageID, url, userAgent, storedCredentialsPolicy, isNavigatingToAppBoundDomain, lastNavigationWasAppInitiated), 0);
+    } else {
+        send(Messages::NetworkProcess::PreconnectToWithCert(sessionID, webPageProxyID, webPageID, url, userAgent, userCertConf, storedCredentialsPolicy, isNavigatingToAppBoundDomain, lastNavigationWasAppInitiated), 0);
+    }
+}
+
 void NetworkProcessProxy::preconnectTo(PAL::SessionID sessionID, WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, const URL& url, const String& userAgent, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
 {
     if (!url.isValid() || !url.protocolIsInHTTPFamily())

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -137,6 +137,7 @@ public:
     void renameOriginInWebsiteData(PAL::SessionID, const URL&, const URL&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
     void websiteDataOriginDirectoryForTesting(PAL::SessionID, URL&&, URL&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
 
+    void preconnectToWithCert(PAL::SessionID, WebPageProxyIdentifier, WebCore::PageIdentifier, const URL&, const String&, const String&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>, LastNavigationWasAppInitiated);
     void preconnectTo(PAL::SessionID, WebPageProxyIdentifier, WebCore::PageIdentifier, const URL&, const String&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>, LastNavigationWasAppInitiated);
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1406,6 +1406,31 @@ WebProcessProxy& WebPageProxy::ensureRunningProcess()
     return m_process;
 }
 
+// this implementation is based on:
+//   RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData)
+RefPtr<API::Navigation> WebPageProxy::loadRequestAndCert(ResourceRequest&& request, API::Object* userData)
+{
+    if (m_isClosed)
+        return nullptr;
+
+    WEBPAGEPROXY_RELEASE_LOG(Loading, "loadRequestAndCert:");
+
+    if (!hasRunningProcess())
+        launchProcess(RegistrableDomain { request.url() }, ProcessLaunchReason::InitialProcess);
+
+    auto navigation = m_navigationState->createLoadRequestNavigation(ResourceRequest(request), m_backForwardList->currentItem());
+
+    if (shouldForceForegroundPriorityForClientNavigation())
+        navigation->setClientNavigationActivity(process().throttler().foregroundActivity("Client navigation"_s));
+
+#if PLATFORM(COCOA)
+    setLastNavigationWasAppInitiated(request);
+#endif
+
+    loadRequestWithNavigationShared(m_process.copyRef(), m_webPageID, navigation.get(), WTFMove(request), WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain());
+    return navigation;
+}
+
 RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData)
 {
     if (m_isClosed)
@@ -1438,6 +1463,8 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     auto transaction = m_pageLoadState.transaction();
 
     auto url = request.url();
+    bool foundCertConf = false;
+
     if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No)
         m_pageLoadState.setPendingAPIRequest(transaction, { navigation.navigationID(), url.string() });
 
@@ -1445,7 +1472,18 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.navigationID = navigation.navigationID();
     loadParameters.request = WTFMove(request);
     loadParameters.shouldOpenExternalURLsPolicy = shouldOpenExternalURLsPolicy;
-    loadParameters.userData = UserData(process->transformObjectsToHandles(userData).get());
+    if (userData && (userData->type() == API::Object::Type::String)) {
+        const ASCIILiteral ENV_WPE_CLIENT_CERTIFICATES_URLS = "WPE_CLIENT_CERTIFICATES_URLS"_s;
+        auto userCertConf = static_cast<API::String*>(userData)->string();
+
+        if (userCertConf.startsWith(ENV_WPE_CLIENT_CERTIFICATES_URLS)) {
+            foundCertConf = true;
+        } else {
+            loadParameters.userData = UserData(process->transformObjectsToHandles(userData).get());
+        }
+    } else {
+        loadParameters.userData = UserData(process->transformObjectsToHandles(userData).get());
+    }
     loadParameters.shouldTreatAsContinuingLoad = shouldTreatAsContinuingLoad;
     loadParameters.websitePolicies = WTFMove(websitePolicies);
     loadParameters.lockHistory = navigation.lockHistory();
@@ -1461,8 +1499,14 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
 
     addPlatformLoadParameters(process, loadParameters);
 
-    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No)
-        preconnectTo(url, predictedUserAgentForRequest(loadParameters.request));
+    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No) {
+        if (foundCertConf) {
+            auto userCertConf = static_cast<API::String*>(userData)->string();
+            preconnectToWithCert(url, predictedUserAgentForRequest(loadParameters.request), userCertConf);
+        } else {
+            preconnectTo(url, predictedUserAgentForRequest(loadParameters.request));
+        }
+    }
 
     navigation.setIsLoadedWithNavigationShared(true);
 
@@ -4795,6 +4839,14 @@ void WebPageProxy::setNetworkRequestsInProgress(bool networkRequestsInProgress)
 {
     auto transaction = m_pageLoadState.transaction();
     m_pageLoadState.setNetworkRequestsInProgress(transaction, networkRequestsInProgress);
+}
+
+void WebPageProxy::preconnectToWithCert(const URL& url, const String& userAgent, const String& userCertConf)
+{
+    if (!m_websiteDataStore->configuration().allowsServerPreconnect())
+        return;
+    auto storedCredentialsPolicy = m_canUseCredentialStorage ? WebCore::StoredCredentialsPolicy::Use : WebCore::StoredCredentialsPolicy::DoNotUse;
+    websiteDataStore().networkProcess().preconnectToWithCert(sessionID(), identifier(), webPageID(), url, userAgent, userCertConf, storedCredentialsPolicy, isNavigatingToAppBoundDomain(), m_lastNavigationWasAppInitiated ? LastNavigationWasAppInitiated::Yes : LastNavigationWasAppInitiated::No);
 }
 
 void WebPageProxy::preconnectTo(const URL& url, const String& userAgent)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -679,6 +679,7 @@ public:
     void closePage();
 
     void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
+    RefPtr<API::Navigation> loadRequestAndCert(WebCore::ResourceRequest&&, API::Object* userData );
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
     RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
     RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
@@ -1995,6 +1996,7 @@ public:
 
     WebPopupMenuProxy* activePopupMenu() const { return m_activePopupMenu.get(); }
 
+    void preconnectToWithCert(const URL&, const String&, const String&);
     void preconnectTo(const URL&, const String& userAgent);
 
     bool canUseCredentialStorage() { return m_canUseCredentialStorage; }


### PR DESCRIPTION
Implemented a new flow to process the certificate data signaled in at runtime as a request query parameters &clientcert=&lt;cert path&gt; and &clientcertkey=&lt;cert path&gt;