### PR TITLE
ARRISEOS-45973: Initial support for instant rate

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4164,7 +4164,7 @@ void HTMLMediaElement::scanTimerFired()
 
 // The spec says to fire periodic timeupdate events (those sent while playing) every
 // "15 to 250ms", we choose the slowest frequency
-static const Seconds maxTimeupdateEventFrequency { 250_ms };
+static const Seconds maxTimeupdateEventFrequency { 200_ms };
 
 void HTMLMediaElement::startPlaybackProgressTimer()
 {
@@ -4211,8 +4211,8 @@ void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
     MonotonicTime now = MonotonicTime::now();
     Seconds timedelta = now - m_clockTimeAtLastUpdateEvent;
 
-    // throttle the periodic events
-    if (periodicEvent && timedelta < maxTimeupdateEventFrequency)
+    // Throttle the periodic events, but leave some room for timers that run slightly faster than expected.
+    if (periodicEvent && timedelta < (maxTimeupdateEventFrequency - 50_ms))
         return;
 
     // Some media engines make multiple "time changed" callbacks at the same time, but we only want one

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -107,6 +107,7 @@ WEBKIT_OPTION_DEFINE(USE_GSTREAMER_HOLEPUNCH "Whether to enable GStreamer holepu
 WEBKIT_OPTION_DEFINE(USE_EXTERNAL_HOLEPUNCH "Whether to enable external holepunch" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_ACCELERATED_2D_CANVAS "Whether to enable accelerated 2D canvas" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_OIPF_VK "Whether to enable OIPF keys for DAE applications" PRIVATE OFF)
+WEBKIT_OPTION_DEFINE(ENABLE_INSTANT_RATE_CHANGE "Whether to enable instant rate change" PRIVATE OFF)
 
 # Supported platforms.
 WEBKIT_OPTION_DEFINE(USE_WPEWEBKIT_PLATFORM_WESTEROS "Whether to enable support for the Westeros platform" PUBLIC OFF)


### PR DESCRIPTION
"custom-instant-rate-change" will do instant rate change without flush.
This change is based on Comcast patch:
https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/rdk-oe/meta-rdk-ext/+/refs/heads/rdk-next/recipes-extended/wpe-webkit/files/2.38.2/comcast-AMLOGIC-3262-Initial-support-for-instant-rat.patch

This fixes YTB MSE Progressive Tests 29, 30, 32, 33 (granularity) by increasing the time granularity to better values (200ms on average, the spec allows a range from 15 to 250ms).