### PR TITLE
ONEM-36490: [WPE-2.38] No logs are seeing in web-inspector

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -660,9 +660,8 @@ Document::~Document()
 {
     ASSERT(activeDOMObjectsAreStopped());
 
-    //ONEM-34447: nothing to remove
-    //if (m_logger)
-    //    m_logger->removeObserver(*this);
+    if (m_logger)
+        m_logger->removeObserver(*this);
 
     if (m_intersectionObserverData) {
         for (const auto& observer : m_intersectionObserverData->observers) {
@@ -8478,8 +8477,7 @@ Logger& Document::logger()
         m_logger = Logger::create(this);
         auto* page = this->page();
         m_logger->setEnabled(this, page && page->sessionID().isAlwaysOnLoggingAllowed());
-        //ONEM-34447: Do not add the observer - this generates too many logs in webinspector
-        //m_logger->addObserver(*this);
+        m_logger->addObserver(*this);
     }
 
     return *m_logger;


### PR DESCRIPTION
No logs are seeing in web-inspector console tab with LGI WPE-2.38 branch
In WPE 2.22, we don't see this an issue.
It was a regression in WPE 2.38 branch.
this patch:
https://github.com/LibertyGlobal/WPEWebKit/commit/072a3e6b1f6d36446331513669236e4a8031a3db

Only reverting the document.cpp file is enough to get the logs on web-inspector console.
