### PR TITLE
ARRISEOS-45835 : [WPE 2.38][Videoland] Videoland application version …

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3419,7 +3419,9 @@ MediaTime HTMLMediaElement::currentMediaTime() const
     if (!m_player)
         return MediaTime::zeroTime();
 
-    if (m_defaultPlaybackStartPosition != MediaTime::zeroTime())
+    // Based on the commit : https://github.com/LibertyGlobal/WPEWebKit/commit/a7f9b178bfe7382a495943cd57efac7023df8eae,
+    // m_defaultPlaybackStartPosition needs to be higher than zero
+    if (m_defaultPlaybackStartPosition > MediaTime::zeroTime())
         return m_defaultPlaybackStartPosition;
 
     if (m_seeking) {


### PR DESCRIPTION
…1.24.2 with WPE 2.38 video playout looping first few frames

Based on the commit: https://github.com/LibertyGlobal/WPEWebKit/commit/a7f9b178bfe7382a495943cd57efac7023df8eae, m_defaultPlaybackStartPosition needs to be higher than zero. Otherwise, if the application passes negative seek position, this will lead into seek getting triggered in a loop and eventually the playback fails.