### PR TITLE
ARRISEOS-46174: allow to pass "stuns" locators

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -465,7 +465,7 @@ ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> RTCPeerConnection
                         if (server.credential.utf8().length() > MaxTurnUsernameLength || server.username.utf8().length() > MaxTurnUsernameLength)
                             return Exception { TypeError, "TURN/TURNS username and/or credential are too long"_s };
                     }
-                } else if (!serverURL.protocolIs("stun"_s))
+                } else if (!serverURL.protocolIs("stun"_s) && !serverURL.protocolIs("stuns"_s))
                     return Exception { NotSupportedError, "ICE server protocol not supported"_s };
             }
             if (serverURLs.size())


### PR DESCRIPTION
It is kind of a cheating like done for the PC Chrome implementation. We could accept stuns locator, but the internal implementation in libwebrtc would do stun via UDP requests for that.
