### PR TITLE
ARRISEOS-45835 [WPE 2.38][Videoland] Video playout looping - sr202

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-currentTime-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-currentTime-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL seek to currentTime assert_greater_than: seekable ranges expected a number greater than 0 but got 0
+PASS seek to currentTime
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL seek to negative time assert_equals: currentTime after setting expected 0 but got -1
+PASS seek to negative time
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -804,6 +804,7 @@ webkit.org/b/240782 fast/text/install-font-style-recalc.html [ Skip ]
 # GStreamer-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
 
+webkit.org/b/278913 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-max-value.htm [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/mimeType.html [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/mute-tracks.html [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/video-rotation.html [ Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT seeking to the end of looping audio Test timed out
+PASS seeking to the end of looping audio
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL seek to negative time The index is not in the allowed range.
-

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/video_loop_base-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/video_loop_base-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-NOTRUN Check if video.loop is set to true that expecting the seeking event is fired more than once
+PASS Check if video.loop is set to true that expecting the seeking event is fired more than once
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3497,6 +3497,8 @@ ExceptionOr<void> HTMLMediaElement::setCurrentTimeForBindings(double time)
     if (m_mediaController)
         return Exception { InvalidStateError };
 
+    time = clampTo(time, 0.0);
+
     if (m_readyState == HAVE_NOTHING || !m_player) {
         m_defaultPlaybackStartPosition = MediaTime::createWithDouble(time);
         return { };

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -753,12 +753,14 @@ std::unique_ptr<PlatformTimeRanges> MediaPlayerPrivateGStreamer::buffered() cons
 
 MediaTime MediaPlayerPrivateGStreamer::maxMediaTimeSeekable() const
 {
-    GST_TRACE_OBJECT(pipeline(), "errorOccured: %s, isLiveStream: %s", boolForPrinting(m_didErrorOccur), boolForPrinting(m_isLiveStream));
+    GST_TRACE_OBJECT(pipeline(), "errorOccured: %s", boolForPrinting(m_didErrorOccur));
     if (m_didErrorOccur)
         return MediaTime::zeroTime();
 
-    if (m_isLiveStream.value_or(false))
-        return MediaTime::zeroTime();
+    bool isLiveStream = m_isLiveStream.value_or(false);
+    GST_TRACE_OBJECT(pipeline(), "isLiveStream: %s", boolForPrinting(isLiveStream));
+    if (isLiveStream)
+        return MediaTime::positiveInfiniteTime();
 
     if (isMediaStreamPlayer())
         return MediaTime::zeroTime();


### PR DESCRIPTION
- orignal upstream commit 081be276c2aad615354966555af0bd0c6b49e9ad:

Clamp setCurrentTimeFromBindings to prevent negative time https://bugs.webkit.org/show_bug.cgi?id=278646

Reviewed by Eric Carlson.

Just clamp the value to avoid negative numbers when seeking.

Also return in GStreamer ports infinity as maxTimeSeekable for live streams.

Test: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time.htm

Also another bunch of tests have now corrected expectations.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-currentTime-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/video_loop_base-expected.txt:
* Source/WebCore/html/HTMLMediaElement.cpp: (WebCore::HTMLMediaElement::setCurrentTimeForBindings):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp: (WebCore::MediaPlayerPrivateGStreamer::maxTimeSeekable const):

Canonical link: https://commits.webkit.org/283134@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
