### PR TITLE
ARRISEOS-45892 GC/bmalloc finetuning + upstream fixes

### DIFF
--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -41,7 +41,7 @@ void FullGCActivityCallback::doCollection(VM& vm)
     Heap& heap = vm.heap;
     m_didGCRecently = false;
 
-#if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
+#if (!PLATFORM(IOS_FAMILY) && !PLATFORM(BROADCOM)) || PLATFORM(MACCATALYST)
     MonotonicTime startTime = MonotonicTime::now();
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure() && heap.isPagedOut()) {
         cancel();

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -807,7 +807,7 @@ void VM::shrinkFootprintWhenIdle()
 {
     whenIdle([=, this] () {
         sanitizeStackForVM(*this);
-        deleteAllCode(DeleteAllCodeIfNotCollecting);
+        deleteAllCode(PreventCollectionAndDeleteAllCode);
         heap.collectNow(Synchronousness::Sync, CollectionScope::Full);
         // FIXME: Consider stopping various automatic threads here.
         // https://bugs.webkit.org/show_bug.cgi?id=185447

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -165,6 +165,7 @@ static const char* toString(MemoryUsagePolicy policy)
     case MemoryUsagePolicy::Unrestricted: return "Unrestricted";
     case MemoryUsagePolicy::Conservative: return "Conservative";
     case MemoryUsagePolicy::Strict: return "Strict";
+    case MemoryUsagePolicy::StrictSynchronous: return "StrictSynchronous";
     }
     ASSERT_NOT_REACHED();
     return "";
@@ -226,6 +227,8 @@ size_t MemoryPressureHandler::thresholdForPolicy(MemoryUsagePolicy policy, Memor
         return m_configuration.conservativeThresholdFraction * (type == MemoryType::Normal ? m_configuration.baseThreshold : m_configuration.baseThresholdVideo);
     case MemoryUsagePolicy::Strict:
         return m_configuration.strictThresholdFraction * (type == MemoryType::Normal ? m_configuration.baseThreshold : m_configuration.baseThresholdVideo);
+    case MemoryUsagePolicy::StrictSynchronous:
+        return type == MemoryType::Normal ? m_configuration.baseThreshold : m_configuration.baseThresholdVideo;
     default:
         ASSERT_NOT_REACHED();
         return 0;
@@ -234,6 +237,8 @@ size_t MemoryPressureHandler::thresholdForPolicy(MemoryUsagePolicy policy, Memor
 
 MemoryUsagePolicy MemoryPressureHandler::policyForFootprints(size_t footprint, size_t footprintVideo)
 {
+    if (footprint >= thresholdForPolicy(MemoryUsagePolicy::StrictSynchronous, MemoryType::Normal) || footprintVideo >= thresholdForPolicy(MemoryUsagePolicy::StrictSynchronous, MemoryType::Video))
+        return MemoryUsagePolicy::StrictSynchronous;
     if (footprint >= thresholdForPolicy(MemoryUsagePolicy::Strict, MemoryType::Normal) || footprintVideo >= thresholdForPolicy(MemoryUsagePolicy::Strict, MemoryType::Video))
         return MemoryUsagePolicy::Strict;
     if (footprint >= thresholdForPolicy(MemoryUsagePolicy::Conservative, MemoryType::Normal) || footprintVideo >= thresholdForPolicy(MemoryUsagePolicy::Conservative, MemoryType::Video))
@@ -306,6 +311,13 @@ void MemoryPressureHandler::measurementTimerFired()
         break;
     case MemoryUsagePolicy::Strict:
         releaseMemory(Critical::Yes, Synchronous::No);
+        break;
+    case MemoryUsagePolicy::StrictSynchronous:
+        WTFLogAlways("MemoryPressure: Critical memory usage (PID=%d) [MB]: %zu/%zu, video: %zu/%zu\n",
+                     getpid(),
+                     footprint / MB, m_configuration.baseThreshold / MB,
+                     footprintVideo / MB, m_configuration.baseThresholdVideo / MB);
+        releaseMemory(Critical::Yes, Synchronous::Yes);
         break;
     }
 

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -40,7 +40,7 @@ namespace WTF {
 
 WTF_EXPORT_PRIVATE bool MemoryPressureHandler::ReliefLogger::s_loggingEnabled = false;
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(BROADCOM)
 static const double s_conservativeThresholdFraction = 0.5;
 static const double s_strictThresholdFraction = 0.65;
 #else
@@ -48,12 +48,21 @@ static const double s_conservativeThresholdFraction = 0.8;
 static const double s_strictThresholdFraction = 0.9;
 #endif
 static const std::optional<double> s_killThresholdFraction;
-static const Seconds s_pollInterval = 30_s;
+static const Seconds s_pollInterval = 5_s;
 
 // This file contains the amount of video memory used, and will be filled by some other
 // platform component. It's a text file containing an unsigned integer value.
 static String s_GPUMemoryFile;
 static ssize_t s_envBaseThresholdVideo = 0;
+
+static double from_env_or_default(const char *envname, double defaultValue) {
+    double val = defaultValue;
+    const char *ev = getenv(envname);
+    if (ev) {
+        val = atof(ev);
+    }
+    return val;
+}
 
 static bool isWebProcess()
 {
@@ -451,8 +460,8 @@ void MemoryPressureHandler::setDispatchQueue(OSObjectPtr<dispatch_queue_t>&& que
 MemoryPressureHandler::Configuration::Configuration()
     : baseThreshold(std::min(3 * GB, ramSize()))
     , baseThresholdVideo(1 * GB)
-    , conservativeThresholdFraction(s_conservativeThresholdFraction)
-    , strictThresholdFraction(s_strictThresholdFraction)
+    , conservativeThresholdFraction(from_env_or_default("WPE_MEMORY_PRESSURE_HANDLER_CONSERVATIVE_THRESHOLD_FRACTION",s_conservativeThresholdFraction))
+    , strictThresholdFraction(from_env_or_default("WPE_MEMORY_PRESSURE_HANDLER_STRICT_THRESHOLD_FRACTION", s_strictThresholdFraction))
     , killThresholdFraction(s_killThresholdFraction)
     , pollInterval(s_pollInterval)
 {

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -59,6 +59,7 @@ enum class MemoryUsagePolicy : uint8_t {
     Unrestricted, // Allocate as much as you want
     Conservative, // Maybe you don't cache every single thing
     Strict, // Time to start pinching pennies for real
+    StrictSynchronous, // Time to start pinching pennies for real, and do it now
 };
 
 enum class MemoryType : uint8_t {

--- a/Source/WebCore/Modules/modern-media-controls/controls/icon-service.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/icon-service.js
@@ -74,6 +74,15 @@ const iconService = new class IconService {
     }
 
     // Public
+    get shadowRoot()
+    {
+        return this.shadowRootWeakRef ? this.shadowRootWeakRef.deref() : null;
+    }
+
+    set shadowRoot(shadowRoot)
+    {
+        this.shadowRootWeakRef = new WeakRef(shadowRoot);
+    }
 
     imageForIconAndLayoutTraits(icon, layoutTraits)
     {

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -25,11 +25,10 @@
 
 class MediaController
 {
-
     constructor(shadowRoot, media, host)
     {
-        this.shadowRoot = shadowRoot;
-        this.media = media;
+        this.shadowRootWeakRef = new WeakRef(shadowRoot);
+        this.mediaWeakRef = new WeakRef(media);
         this.host = host;
 
         this.fullscreenChangeEventType = media.webkitSupportsPresentationMode ? "webkitpresentationmodechanged" : "webkitfullscreenchange";
@@ -65,6 +64,16 @@ class MediaController
     }
 
     // Public
+    get media()
+    {
+        return this.mediaWeakRef ? this.mediaWeakRef.deref() : null;
+    }
+
+    get shadowRoot()
+    {
+
+        return this.shadowRootWeakRef ? this.shadowRootWeakRef.deref() : null;
+    }
 
     get isAudio()
     {
@@ -91,6 +100,9 @@ class MediaController
 
     get isFullscreen()
     {
+        if (!this.media)
+            return false;
+
         return this.media.webkitSupportsPresentationMode ? this.media.webkitPresentationMode === "fullscreen" : this.media.webkitDisplayingFullscreen;
     }
 
@@ -203,6 +215,24 @@ class MediaController
             this.togglePlayback();
             event.preventDefault();
         }
+    }
+
+    // HTMLMediaElement
+
+    deinitialize()
+    {
+        this.shadowRoot.removeChild(this.container);
+        return true;
+    }
+
+    reinitialize(shadowRoot, media, host)
+    {
+        iconService.shadowRoot = shadowRoot;
+        this.shadowRootWeakRef = new WeakRef(shadowRoot);
+        this.mediaWeakRef = new WeakRef(media);
+        this.host = host;
+        shadowRoot.appendChild(this.container);
+        return true;
     }
 
     // Private

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -294,6 +294,8 @@ String convertEnumerationToString(HTMLMediaElement::TextTrackVisibilityCheckType
     return values[static_cast<size_t>(enumerationValue)];
 }
 
+static JSC::JSValue controllerJSValue(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&, HTMLMediaElement&);
+
 class TrackDisplayUpdateScope {
 public:
     TrackDisplayUpdateScope(HTMLMediaElement& element)
@@ -444,6 +446,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_parsingInProgress(createdByParser)
     , m_elementIsHidden(document.hidden())
     , m_creatingControls(false)
+    , m_partiallyDeinitialized(false)
     , m_receivedLayoutSizeChanged(false)
     , m_hasEverNotifiedAboutPlaying(false)
     , m_hasEverHadAudio(false)
@@ -876,6 +879,37 @@ void HTMLMediaElement::pauseAfterDetachedTask()
         pause();
     if (m_videoFullscreenMode == VideoFullscreenModeStandard)
         exitFullscreen();
+
+#if ENABLE(MODERN_MEDIA_CONTROLS)
+    if (!m_creatingControls && !m_partiallyDeinitialized && m_mediaControlsHost) {
+        // Call MediaController.deinitialize() to get rid of circular references.
+        m_partiallyDeinitialized = setupAndCallJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
+            auto& vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
+            auto controllerValue = controllerJSValue(lexicalGlobalObject, globalObject, *this);
+            RETURN_IF_EXCEPTION(scope, false);
+            auto* controllerObject = controllerValue.toObject(&lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+
+            auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "deinitialize"_s));
+            if (UNLIKELY(scope.exception()) || functionValue.isUndefinedOrNull())
+                return false;
+
+            auto* function = functionValue.toObject(&lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+
+            auto callData = JSC::getCallData(function);
+            if (callData.type == JSC::CallData::Type::None)
+                return false;
+
+            auto resultValue = JSC::call(&lexicalGlobalObject, function, callData, controllerObject, JSC::MarkedArgumentBuffer());
+            RETURN_IF_EXCEPTION(scope, false);
+
+            return resultValue.toBoolean(&lexicalGlobalObject);
+        });
+    }
+#endif // ENABLE(MODERN_MEDIA_CONTROLS)
 
     if (!m_player)
         return;
@@ -4644,6 +4678,46 @@ void HTMLMediaElement::ensureMediaControlsShadowRoot()
     if (m_creatingControls)
         return;
 
+    if (m_partiallyDeinitialized) {
+        m_partiallyDeinitialized = !setupAndCallJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
+            auto& vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
+            auto controllerValue = controllerJSValue(lexicalGlobalObject, globalObject, *this);
+            RETURN_IF_EXCEPTION(scope, false);
+            auto* controllerObject = controllerValue.toObject(&lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+
+            auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "reinitialize"_s));
+            if (UNLIKELY(scope.exception()) || functionValue.isUndefinedOrNull())
+                return false;
+
+            if (!m_mediaControlsHost)
+                m_mediaControlsHost = MediaControlsHost::create(*this);
+
+            auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *this);
+            auto mediaControlsHostJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *m_mediaControlsHost.copyRef());
+
+            JSC::MarkedArgumentBuffer argList;
+            argList.append(toJS(&lexicalGlobalObject, &globalObject, Ref { ensureUserAgentShadowRoot() }));
+            argList.append(mediaJSWrapper);
+            argList.append(mediaControlsHostJSWrapper);
+            ASSERT(!argList.hasOverflowed());
+
+            auto* function = functionValue.toObject(&lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+
+            auto callData = JSC::getCallData(function);
+            if (callData.type == JSC::CallData::Type::None)
+                return false;
+
+            auto resultValue = JSC::call(&lexicalGlobalObject, function, callData, controllerObject, argList);
+            RETURN_IF_EXCEPTION(scope, false);
+
+            return resultValue.toBoolean(&lexicalGlobalObject);
+        });
+    }
+
     m_creatingControls = true;
     ensureUserAgentShadowRoot();
     m_creatingControls = false;
@@ -7669,6 +7743,9 @@ bool HTMLMediaElement::ensureMediaControlsInjectedScript()
     auto mediaControlsScripts = RenderTheme::singleton().mediaControlsScripts();
     if (mediaControlsScripts.isEmpty())
         return false;
+
+    if (m_partiallyDeinitialized)
+        return true;
 
     return setupAndCallJS([mediaControlsScripts = WTFMove(mediaControlsScripts)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController& scriptController, DOMWrapperWorld& world) {
         auto& vm = globalObject.vm();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1141,6 +1141,7 @@ private:
     bool m_elementIsHidden : 1;
     bool m_elementWasRemovedFromDOM : 1;
     bool m_creatingControls : 1;
+    bool m_partiallyDeinitialized : 1;
     bool m_receivedLayoutSizeChanged : 1;
     bool m_hasEverNotifiedAboutPlaying : 1;
 

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -126,7 +126,7 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
         GCController::singleton().garbageCollectNow();
     } else {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(BROADCOM)
         GCController::singleton().garbageCollectNowIfNotDoneRecently();
 #else
         GCController::singleton().garbageCollectSoon();

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -606,7 +606,7 @@ void WorkerGlobalScope::deleteJSCodeAndGC(Synchronous synchronous)
             return;
         }
     }
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) || PLATFORM(BROADCOM)
     if (!vm().heap.currentThreadIsDoingGCWork()) {
         vm().heap.collectNowFullIfNotDoneRecently(JSC::Async);
         return;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -251,6 +251,10 @@ bool InjectedBundle::isProcessingUserGesture()
 void InjectedBundle::garbageCollectJavaScriptObjects()
 {
     GCController::singleton().garbageCollectNow();
+    WTF::releaseFastMallocFreeMemory();
+
+    JSLockHolder lock(commonVM());
+    commonVM().shrinkFootprintWhenIdle();
 }
 
 void InjectedBundle::garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging(bool waitUntilDone)

--- a/Source/bmalloc/bmalloc/AvailableMemory.cpp
+++ b/Source/bmalloc/bmalloc/AvailableMemory.cpp
@@ -63,6 +63,15 @@ namespace bmalloc {
 
 static constexpr size_t availableMemoryGuess = 512 * bmalloc::MB;
 
+double from_env_or_default(const char *envname, size_t defaultValue) {
+    double val = defaultValue;
+    const char *ev = getenv(envname);
+    if (ev) {
+        val = atof(ev);
+    }
+    return val;
+}
+
 #if BOS(DARWIN)
 static size_t memorySizeAccordingToKernel()
 {
@@ -149,6 +158,29 @@ struct LinuxMemory {
 };
 #endif
 
+static size_t customRAMSize()
+{
+    // Syntax: Case insensitive, unit multipliers (M=Mb, K=Kb, <empty>=bytes).
+    // Example: WPE_RAM_SIZE='500M'
+
+    size_t customSize = 0;
+
+    const char *s = getenv("WPE_RAM_SIZE");
+    if (s) {
+        size_t len = strlen(s);
+        size_t val = atoi(s);
+        size_t units = 1;
+        if (s[len-1] == 'k' || s[len-1] == 'K')
+            units = 1024;
+        else if (s[len-1] == 'm' || s[len-1] == 'M')
+            units = 1024*1024;
+        return units * val;
+    }
+
+    return customSize;
+}
+
+
 static size_t computeAvailableMemory()
 {
 #if BOS(DARWIN)
@@ -162,6 +194,10 @@ static size_t computeAvailableMemory()
     // (for example) and we have code that depends on those boundaries.
     return ((sizeAccordingToKernel + multiple - 1) / multiple) * multiple;
 #elif BOS(FREEBSD) || BOS(LINUX)
+    size_t customRamSize = customRAMSize();
+    if (customRamSize) {
+        return customRamSize;
+    }
     struct sysinfo info;
     if (!sysinfo(&info))
         return info.totalram * info.mem_unit;

--- a/Source/bmalloc/bmalloc/AvailableMemory.h
+++ b/Source/bmalloc/bmalloc/AvailableMemory.h
@@ -32,6 +32,8 @@ namespace bmalloc {
 
 BEXPORT size_t availableMemory();
 
+double from_env_or_default(const char *envname, size_t defaultValue);
+
 #if BPLATFORM(IOS_FAMILY) || BOS(LINUX) || BOS(FREEBSD)
 struct MemoryStatus {
     MemoryStatus(size_t memoryFootprint, double percentAvailableMemoryInUse)
@@ -62,7 +64,8 @@ inline double percentAvailableMemoryInUse()
 inline bool isUnderMemoryPressure()
 {
 #if BPLATFORM(IOS_FAMILY) || BOS(LINUX) || BOS(FREEBSD)
-    return percentAvailableMemoryInUse() > memoryPressureThreshold;
+    static const double effective_memoryPressureThreshold = from_env_or_default("WPE_BMALLOC_MEMORY_PRESSURE_THRESHOLD", memoryPressureThreshold);
+    return percentAvailableMemoryInUse() > effective_memoryPressureThreshold;
 #else
     return false;
 #endif

--- a/Source/bmalloc/bmalloc/Scavenger.cpp
+++ b/Source/bmalloc/bmalloc/Scavenger.cpp
@@ -50,6 +50,8 @@ namespace bmalloc {
 
 static constexpr bool verbose = false;
 
+double from_env_or_default(const char *envname, size_t defaultValue);
+
 struct PrintTime {
     PrintTime(const char* str) 
         : string(str)
@@ -126,8 +128,9 @@ void Scavenger::scheduleIfUnderMemoryPressure(size_t bytes)
 
 void Scavenger::scheduleIfUnderMemoryPressure(const LockHolder& lock, size_t bytes)
 {
+    static const size_t effective_scavengerBytesPerMemoryPressureCheck = (size_t) from_env_or_default("WPE_BMALLOC_SCAVENGER_BYTES_PER_MEMORY_PRESSURE_CHECK", scavengerBytesPerMemoryPressureCheck);
     m_scavengerBytes += bytes;
-    if (m_scavengerBytes < scavengerBytesPerMemoryPressureCheck)
+    if (m_scavengerBytes < effective_scavengerBytesPerMemoryPressureCheck)
         return;
 
     m_scavengerBytes = 0;

--- a/Source/bmalloc/bmalloc/Sizes.h
+++ b/Source/bmalloc/bmalloc/Sizes.h
@@ -68,7 +68,9 @@ static constexpr size_t largeAlignmentMask = largeAlignment - 1;
 static constexpr size_t deallocatorLogCapacity = 512;
 static constexpr size_t bumpRangeCacheCapacity = 3;
 
+// can be overriden with WPE_BMALLOC_SCAVENGER_BYTES_PER_MEMORY_PRESSURE_CHECK env
 static constexpr size_t scavengerBytesPerMemoryPressureCheck = 16 * MB;
+// can be overriden with WPE_BMALLOC_MEMORY_PRESSURE_THRESHOLD env
 static constexpr double memoryPressureThreshold = 0.75;
 
 static constexpr size_t maskSizeClassCount = maskSizeClassMax / alignment;


### PR DESCRIPTION
ARRISEOS-45892 GC/bmalloc finetuning

- some IOS branches related to GC applied also for BROADCOM cases
- MemoryPressureHandler interval decreased
- MemoryPressureHandler threshold configurable with envs:
   WPE_MEMORY_PRESSURE_HANDLER_CONSERVATIVE_THRESHOLD_FRACTION
   WPE_MEMORY_PRESSURE_HANDLER_STRICT_THRESHOLD_FRACTION
- bmalloc memoryPressureThreshold configurable with
  WPE_BMALLOC_MEMORY_PRESSURE_THRESHOLD env
- bmalloc scavengerBytesPerMemoryPressureCheck configurable
  with WPE_BMALLOC_SCAVENGER_BYTES_PER_MEMORY_PRESSURE_CHECK env
- garbageCollectJavaScriptObjects: use shrinkFootprintWhenIdle
- shrinkFootprintWhenIdle: delete all code also when in GC already

contains also 2 upstream cherry-picks:

Author: Enrique Ocaña González [eocanha@igalia.com](mailto:eocanha@igalia.com)
Date: Mon Apr 8 06:44:26 2024 -0700

[Modern Media Controls] HTMLMediaElement is never destroyed when showing media controls
https://bugs.webkit.org/show_bug.cgi?id=270571

Author: Andrzej Surdej [Andrzej_Surdej@comcast.com](mailto:Andrzej_Surdej@comcast.com)
Date: Mon Apr 29 14:10:48 2024 +0200

    [MemoryPressureHandler] Unify critical/synchronous memory pressure events