### PR TITLE
[ARRISEOS-46293] Allow GST_EVENT_CUSTOM_DOWNSTREAM_OOB to propagate w…

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -435,11 +435,16 @@ static gboolean sinkEventHandler(GstBaseTransform* trans, GstEvent* event)
     // handled in here.
     switch (GST_EVENT_TYPE(event)) {
     case GST_EVENT_CUSTOM_DOWNSTREAM_OOB: {
-        ASSERT(gst_event_has_name(event, "attempt-to-decrypt"));
-        GST_DEBUG_OBJECT(self, "Handling attempt-to-decrypt");
-        gboolean result = installCDMProxyIfNotAvailable(self);
-        gst_event_unref(event);
-        return result;
+        GST_DEBUG_OBJECT(self, "Custom Downstream OOB %" GST_PTR_FORMAT, event);
+
+        if (gst_event_has_name(event, "attempt-to-decrypt")) {
+            GST_DEBUG_OBJECT(self, "Handling attempt-to-decrypt");
+            gboolean result = installCDMProxyIfNotAvailable(self);
+            gst_event_unref(event);
+            return result;
+        }
+        // Let event propagate.
+        break;
     }
     case GST_EVENT_FLUSH_START:
         GST_DEBUG_OBJECT(self, "Flush-start");


### PR DESCRIPTION
…hen not handled

https://bugs.webkit.org/show_bug.cgi?id=271041

Reviewed by Philippe Normand.

We may wish to use GST_EVENT_CUSTOM_DOWNSTREAM_OOB event for use cases beyond signaling an "attempt-to-decrypt".

Patch by Filipe Norte <filipe.norte@sky.uk>.

* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp: (sinkEventHandler):

Canonical link: https://commits.webkit.org/276144@main