### PR TITLE
[ARRISEOS-46060]-Thumbnail Images partially Displayed Black Before Fu…

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1115,7 +1115,6 @@ IntRect CoordinatedGraphicsLayer::transformedVisibleRect()
 
 IntRect CoordinatedGraphicsLayer::transformedVisibleRectIncludingFuture()
 {
-	fprintf(stderr,"Gowthami--patch1\n");
     auto visibleRectIncludingFuture = transformedVisibleRect();
     if (m_cachedInverseTransform != m_cachedFutureInverseTransform) {
         FloatRect rect = m_cachedFutureInverseTransform.clampedBoundsOfProjectedQuad(FloatQuad(m_coordinator->visibleContentsRect()));

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1113,6 +1113,18 @@ IntRect CoordinatedGraphicsLayer::transformedVisibleRect()
     return enclosingIntRect(rect);
 }
 
+IntRect CoordinatedGraphicsLayer::transformedVisibleRectIncludingFuture()
+{
+	fprintf(stderr,"Gowthami--patch1\n");
+    auto visibleRectIncludingFuture = transformedVisibleRect();
+    if (m_cachedInverseTransform != m_cachedFutureInverseTransform) {
+        FloatRect rect = m_cachedFutureInverseTransform.clampedBoundsOfProjectedQuad(FloatQuad(m_coordinator->visibleContentsRect()));
+        clampToContentsRectIfRectIsInfinite(rect, size());
+        visibleRectIncludingFuture.unite(enclosingIntRect(rect));
+    }
+    return visibleRectIncludingFuture;
+}
+
 void CoordinatedGraphicsLayer::requestBackingStoreUpdate()
 {
     setNeedsVisibleRectAdjustment();
@@ -1185,7 +1197,7 @@ void CoordinatedGraphicsLayer::updateContentBuffers()
 
     if (m_pendingVisibleRectAdjustment) {
         m_pendingVisibleRectAdjustment = false;
-        layerState.mainBackingStore->createTilesIfNeeded(transformedVisibleRect(), IntRect(0, 0, m_size.width(), m_size.height()));
+        layerState.mainBackingStore->createTilesIfNeeded(transformedVisibleRectIncludingFuture(), IntRect(0, 0, m_size.width(), m_size.height()));
     }
 
     if (is<CoordinatedAnimatedBackingStoreClient>(m_nicosia.animatedBackingStoreClient)) {
@@ -1375,8 +1387,13 @@ void CoordinatedGraphicsLayer::computeTransformedVisibleRect()
 
     m_shouldUpdateVisibleRect = false;
     TransformationMatrix currentTransform = transform();
-    if (m_movingVisibleRect)
+        TransformationMatrix futureTransform = currentTransform;
+    if (m_movingVisibleRect) {
         client().getCurrentTransform(this, currentTransform);
+	        Nicosia::Animation::ApplicationResult futureApplicationResults;
+        m_animations.applyKeepingInternalState(futureApplicationResults, MonotonicTime::now() + 300_ms);
+        futureTransform = futureApplicationResults.transform.value_or(currentTransform);
+    }
     m_layerTransform.setLocalTransform(currentTransform);
 
     m_layerTransform.setAnchorPoint(m_adjustedAnchorPoint);
@@ -1388,6 +1405,15 @@ void CoordinatedGraphicsLayer::computeTransformedVisibleRect()
     m_layerTransform.combineTransforms(parent() ? downcast<CoordinatedGraphicsLayer>(*parent()).m_layerTransform.combinedForChildren() : TransformationMatrix());
 
     m_cachedInverseTransform = m_layerTransform.combined().inverse().value_or(TransformationMatrix());
+
+        m_layerFutureTransform = m_layerTransform;
+    m_cachedFutureInverseTransform = m_cachedInverseTransform;
+    CoordinatedGraphicsLayer* parentLayer = downcast<CoordinatedGraphicsLayer>(parent());
+    if (currentTransform != futureTransform || (parentLayer && parentLayer->m_layerTransform.combinedForChildren() != parentLayer->m_layerFutureTransform.combinedForChildren())) {
+        m_layerFutureTransform.setLocalTransform(futureTransform);
+        m_layerFutureTransform.combineTransforms(parentLayer ? parentLayer->m_layerFutureTransform.combinedForChildren() : TransformationMatrix());
+        m_cachedFutureInverseTransform = m_layerFutureTransform.combined().inverse().value_or(TransformationMatrix());
+    }
 
     // The combined transform will be used in tiledBackingStoreVisibleRect.
     setNeedsVisibleRectAdjustment();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -134,7 +134,7 @@ public:
     void computePixelAlignment(FloatPoint& position, FloatSize&, FloatPoint3D& anchorPoint, FloatSize& alignmentOffset);
 
     IntRect transformedVisibleRect();
-
+    IntRect transformedVisibleRectIncludingFuture();
     void invalidateCoordinator();
     void setCoordinatorIncludingSubLayersIfNeeded(CoordinatedGraphicsLayerClient*);
 
@@ -211,7 +211,9 @@ private:
 
     Nicosia::PlatformLayer::LayerID m_id;
     GraphicsLayerTransform m_layerTransform;
+    GraphicsLayerTransform m_layerFutureTransform;
     TransformationMatrix m_cachedInverseTransform;
+    TransformationMatrix m_cachedFutureInverseTransform;
     FloatSize m_pixelAlignmentOffset;
     FloatSize m_adjustedSize;
     FloatPoint m_adjustedPosition;


### PR DESCRIPTION
1. Summary:
When scrolling through the carousel slider, thumbnail image initially displays only half of the image, with the other half appearing black. After approximately 2 seconds, the full image loads properly. This issue persists when scrolling to the next thumbnail. It seems like there's a delay or inconsistency in loading the image, causing a visual glitch.

Some of the impacted apps : DAZN , Viaplay, TG4 etc

2. Severity:
Medium

3. Replication steps:
1.Lauch the application will navigate to Home page.
2.Start scrolling the carousel slider with thumbnails in the top of the Home page.

4. Actual results:
Upon the first visibility, each thumbnail initially displays only half of the image, with the other half black. After a short delay the full image loads properly.

5. Expected results:
Thumbnail image should load promptly and display fully without any visual artifacts.

6. Frequency (percentage):
100%
