### PR TITLE
[ONEM-36631]- EB for testing avreports issue

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5765,7 +5765,10 @@ void HTMLMediaElement::updatePlayState()
     if (shouldBePlaying) {
         invalidateCachedTime();
 
-        if (playerPaused) {
+	ALWAYS_LOG(LOGIDENTIFIER, "Gowthami-m_seeking = ", m_seeking, ", Gowthami-playerPaused = ", playerPaused);
+
+        if (playerPaused && !m_seeking) {
+                ALWAYS_LOG(LOGIDENTIFIER, "Gowthami-m_seeking condition");
             mediaSession().clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.


### PR DESCRIPTION
Issue : 
Sometimes state=play is observed in between state=seek_start and state=seek_done

Test Details : 
Build- VIP7002W-mon-dbg-06.04-000-aa-AL-20240822210000-un000
Country config -NL

Reproduction rate:
Atleast once in 10 attempts 

Steps to Reproduce & Results : 

1. Ensure that reportingPeriodicity is set to 1 for gstreamer AVPipelineReport in main config file (vi /usr/share/lgias/data/configuration/main.json)

 "gstreamer": {
      "AVPipelineReport": {
        "reportingPeriodicity": 1
      }
2. Open CNN and start to play some video

3. Do seek using seek button shown on UI and then Run following command on the box

sed 's/},{/}\n\n{/g' /usr/share/lgias/data/usage-collector/buffers/buffer* | grep "AVPipelineReport.*wpe"