### PR TITLE
ARRISEOS-46417 CachedResourceLoader: return early if document is null

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -564,6 +564,8 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
     ASSERT(m_documentLoader);
     if (auto* document = m_documentLoader->cachedResourceLoader().document())
         upgradeInsecureResourceRequestIfNeeded(request, *document);
+    else
+        return false;
 
     // FIXME: We might want to align the checks done here with the ones done in CachedResourceLoader::requestResource, content extensions blocking in particular.
 


### PR DESCRIPTION
This is to prevent nullptr-related crashes with stack like:

 0  libWPEWebKit-0.1.so.2!WebCore::CachedResourceLoader::allowedByContentSecurityPolicy(WebCore::CachedResource::Type, WebCore::URL const&, WebCore::ResourceLoaderOptions const&, WebCore::ContentSecurityPolicy::RedirectResponseReceived) const [CachedResourceLoader.cpp : 439 + 0x0]
 
 1  libWPEWebKit-0.1.so.2!WebCore::CachedResourceLoader::canRequestAfterRedirection(WebCore::CachedResource::Type, WebCore::URL const&, WebCore::ResourceLoaderOptions const&) const [CachedResourceLoader.cpp : 428 + 0x13]
 
 2  libWPEWebKit-0.1.so.2!WebCore::SubresourceLoader::willSendRequestInternal(WebCore::ResourceRequest&&, WebCore::ResourceResponse const&, WTF::CompletionHandler<void(WebCore::ResourceRequest&&)>&&) [SubresourceLoader.cpp : 247 + 0xf]
 
 3  libWPEWebKit-0.1.so.2!WebKit::WebResourceLoader::willSendRequest(WebCore::ResourceRequest&&, WebCore::ResourceResponse&&) [WebResourceLoader.cpp : 94 + 0x1]
 
 4  libWPEWebKit-0.1.so.2!void IPC::handleMessage<Messages::WebResourceLoader::WillSendRequest, WebKit::WebResourceLoader, void (WebKit::WebResourceLoader::*(WebCore::ResourceRequest&&, WebCore::ResourceResponse&&)>(IPC::Decoder&, WebKit::WebResourceLoader*, void (WebKit::WebResourceLoader::* (WebCore::ResourceRequest&&, WebCore::ResourceResponse&&)) [HandleMessage.h : 41 + 0x19]
 
 5  libWPEWebKit-0.1.so.2!WebKit::WebResourceLoader::didReceiveWebResourceLoaderMessage(IPC::Connection&, IPC::Decoder&) [WebResourceLoaderMessageReceiver.cpp : 49 + 0x13]
