### PR TITLE
ARRISEOS-46168: integrate upstream changes

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -2576,6 +2576,21 @@ WebMParserEnabled:
     WebKit:
       default: true
 
+WebRTCUDPPortRange:
+  type: String
+  status: embedder
+  category: media
+  humanReadableName: "WebRTC UDP Port Range"
+  humanReadableDescription: "Set a UDP port range for WebRTC. If set to 0:0, the port range is determined by the OS"
+  condition: ENABLE(WEB_RTC)
+  defaultValue:
+    WebKitLegacy:
+      default: '"0:0"_str'
+    WebKit:
+      default: '"0:0"_str'
+    WebCore:
+      default: '"0:0"_str'
+
 WebSecurityEnabled:
   type: bool
   inspectorOverride: true

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -597,6 +597,7 @@ void Page::settingsDidChange()
     m_webRTCProvider->setH265Support(settings().webRTCH265CodecEnabled());
     m_webRTCProvider->setVP9Support(settings().webRTCVP9Profile0CodecEnabled(), settings().webRTCVP9Profile2CodecEnabled());
     m_webRTCProvider->setAV1Support(settings().webRTCAV1CodecEnabled());
+    m_webRTCProvider->setPortAllocatorRange(settings().webRTCUDPPortRange());
 #endif
 }
 

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -34,6 +34,7 @@
 
 #include <wtf/Function.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
@@ -305,6 +306,31 @@ std::optional<MediaCapabilitiesDecodingInfo> WebRTCProvider::videoDecodingCapabi
 std::optional<MediaCapabilitiesEncodingInfo> WebRTCProvider::videoEncodingCapabilitiesOverride(const VideoConfiguration&)
 {
     return { };
+}
+
+void WebRTCProvider::setPortAllocatorRange(StringView range)
+{
+    auto components = range.toStringWithoutCopying().split(':');
+    if (UNLIKELY(components.size() != 2)) {
+        WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto minPort = WTF::parseInteger<int>(components[0]).value_or(0);
+    auto maxPort = WTF::parseInteger<int>(components[1]).value_or(0);
+    if (!minPort || !maxPort) {
+        WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_portAllocatorRange = { { minPort, maxPort } };
+}
+
+std::optional<std::pair<int, int>> WebRTCProvider::portAllocatorRange() const
+{
+    return m_portAllocatorRange;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -310,6 +310,12 @@ std::optional<MediaCapabilitiesEncodingInfo> WebRTCProvider::videoEncodingCapabi
 
 void WebRTCProvider::setPortAllocatorRange(StringView range)
 {
+    if (range.isEmpty())
+        return;
+
+    if (range == "0:0"_s)
+        return;
+
     auto components = range.toStringWithoutCopying().split(':');
     if (UNLIKELY(components.size() != 2)) {
         WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
@@ -317,15 +323,25 @@ void WebRTCProvider::setPortAllocatorRange(StringView range)
         return;
     }
 
-    auto minPort = WTF::parseInteger<int>(components[0]).value_or(0);
-    auto maxPort = WTF::parseInteger<int>(components[1]).value_or(0);
+    auto minPort = WTF::parseInteger<int>(components[0]);
+    auto maxPort = WTF::parseInteger<int>(components[1]);
     if (!minPort || !maxPort) {
         WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
         ASSERT_NOT_REACHED();
         return;
     }
 
-    m_portAllocatorRange = { { minPort, maxPort } };
+    if (*minPort < 0) {
+        WTFLogAlways("Invalid value for UDP minimum port value: %d", *minPort);
+        return;
+    }
+
+    if (*maxPort < 0) {
+        WTFLogAlways("Invalid value for UDP maximum port value: %d", *maxPort);
+        return;
+    }
+
+    m_portAllocatorRange = { { *minPort, *maxPort } };
 }
 
 std::optional<std::pair<int, int>> WebRTCProvider::portAllocatorRange() const

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.h
@@ -81,6 +81,9 @@ public:
     virtual void setLoggingLevel(WTFLogLevel);
     virtual void clearFactory();
 
+    void setPortAllocatorRange(StringView);
+    std::optional<std::pair<int, int>> portAllocatorRange() const;
+
 protected:
 #if ENABLE(WEB_RTC)
     std::optional<RTCRtpCapabilities>& audioDecodingCapabilities();
@@ -106,6 +109,8 @@ protected:
     bool m_supportsVP9Profile0 { false };
     bool m_supportsVP9Profile2 { false };
     bool m_supportsMDNS { false };
+
+    std::optional<std::pair<int, int>> m_portAllocatorRange;
 
 private:
     virtual void initializeAudioDecodingCapabilities();

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -399,6 +399,9 @@ rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPee
     if (!factory)
         return nullptr;
 
+    if (auto portRange = portAllocatorRange())
+        portAllocator->SetPortRange(portRange->first, portRange->second);
+
     webrtc::PeerConnectionDependencies dependencies { &observer };
     dependencies.allocator = WTFMove(portAllocator);
     dependencies.async_resolver_factory = WTFMove(asyncResolveFactory);

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -399,6 +399,10 @@ rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPee
     if (!factory)
         return nullptr;
 
+    auto portRangeFromEnvironment = StringView::fromLatin1(std::getenv("WEBKIT_WEBRTC_PEER_PORT_RANGE"));
+    if (!portRangeFromEnvironment.isEmpty())
+        setPortAllocatorRange(portRangeFromEnvironment);
+
     if (auto portRange = portAllocatorRange())
         portAllocator->SetPortRange(portRange->first, portRange->second);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -1773,7 +1773,8 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
      * In some constrained environments where a firewall blocks UDP network traffic excepted on a
      * specific port range, this settings can be used to give hints to the WebRTC backend regarding
      * which ports to allocate. The format is min-port:max-port, so for instance 20000:30000. The
-     * default value is 0:0 which means the OS will use no hints from the WebRTC backend.
+     * default empty string value means the OS will use no hints from the WebRTC backend. Using 0
+     * for one of the values is allowed and means the value is unspecified.
      *
      * Since: 2.48
      */

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -67,6 +67,9 @@ struct _WebKitSettingsPrivate {
         fantasyFontFamily = preferences->fantasyFontFamily().utf8();
         pictographFontFamily = preferences->pictographFontFamily().utf8();
         defaultCharset = preferences->defaultTextEncodingName().utf8();
+#if ENABLE(WEB_RTC)
+        webrtcUDPPortsRange = preferences->webRTCUDPPortRange().utf8();
+#endif
     }
 
     RefPtr<WebPreferences> preferences;
@@ -80,6 +83,9 @@ struct _WebKitSettingsPrivate {
     CString defaultCharset;
     CString userAgent;
     CString mediaContentTypesRequiringHardwareSupport;
+#if ENABLE(WEB_RTC)
+    CString webrtcUDPPortsRange;
+#endif
     bool allowModalDialogs { false };
     bool zoomTextOnly { false };
 #if PLATFORM(GTK)
@@ -180,6 +186,7 @@ enum {
     PROP_ALLOW_MOVE_TO_SUSPEND_ON_WINDOW_CLOSE,
     PROP_ENABLE_DIRECTORY_UPLOAD,
     PROP_ENABLE_ICE_CANDIDATE_FILTERING,
+    PROP_WEBRTC_UDP_PORTS_RANGE,
     N_PROPERTIES,
 };
 
@@ -434,6 +441,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     case PROP_ENABLE_ICE_CANDIDATE_FILTERING:
         webkit_settings_set_enable_ice_candidate_filtering(settings, g_value_get_boolean(value));
         break;
+    case PROP_WEBRTC_UDP_PORTS_RANGE:
+        webkit_settings_set_webrtc_udp_ports_range(settings, g_value_get_string(value));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -658,6 +668,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
     case PROP_ENABLE_ICE_CANDIDATE_FILTERING:
         g_value_set_boolean(value, webkit_settings_get_enable_ice_candidate_filtering(settings));
+        break;
+    case PROP_WEBRTC_UDP_PORTS_RANGE:
+        g_value_set_string(value, webkit_settings_get_webrtc_udp_ports_range(settings));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -1750,6 +1763,25 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         _("Enable ICE candidate filtering"),
         _("Whether ICE candidate filtering should be enabled."),
         FALSE,
+        readWriteConstructParamFlags);
+
+    /**
+     * WebKitSettings:webrtc-udp-ports-range:
+     *
+     * Allow customization of the WebRTC UDP ports range.
+     *
+     * In some constrained environments where a firewall blocks UDP network traffic excepted on a
+     * specific port range, this settings can be used to give hints to the WebRTC backend regarding
+     * which ports to allocate. The format is min-port:max-port, so for instance 20000:30000. The
+     * default value is 0:0 which means the OS will use no hints from the WebRTC backend.
+     *
+     * Since: 2.48
+     */
+    sObjProperties[PROP_WEBRTC_UDP_PORTS_RANGE] = g_param_spec_string(
+        "webrtc-udp-ports-range",
+        _("WebRTC UDP ports range"),
+        _("WebRTC UDP ports range, the format is min-port:max-port"),
+        nullptr, // A null string forces the default value.
         readWriteConstructParamFlags);
 
     g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
@@ -4404,4 +4436,52 @@ void webkit_settings_set_enable_ice_candidate_filtering(WebKitSettings* settings
 
     priv->preferences->setICECandidateFilteringEnabled(enabled);
     g_object_notify(G_OBJECT(settings), "enable-ice-candidate-filtering");
+}
+
+/**
+ * webkit_settings_get_webrtc_udp_ports_range:
+ * @settings: a #WebKitSettings
+ *
+ * Get the [property@Settings:webrtc-udp-ports-range] property.
+ *
+ * Returns: The WebRTC UDP ports range, or %NULL if un-set.
+ *
+ * Since: 2.48
+ */
+const gchar*
+webkit_settings_get_webrtc_udp_ports_range(WebKitSettings* settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+#if ENABLE(WEB_RTC)
+    return settings->priv->webrtcUDPPortsRange.data();
+#else
+    return nullptr;
+#endif
+}
+
+/**
+ * webkit_settings_set_webrtc_udp_ports_range:
+ * @settings: a #WebKitSettings
+ * @udp_port_range: Value to be set
+ *
+ * Set the [property@Settings:webrtc-udp-ports-range] property.
+ *
+ * Since: 2.48
+ */
+void
+webkit_settings_set_webrtc_udp_ports_range(WebKitSettings* settings, const gchar* udpPortsRange)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+#if ENABLE(WEB_RTC)
+    WebKitSettingsPrivate* priv = settings->priv;
+    if (!g_strcmp0(priv->webrtcUDPPortsRange.data(), udpPortsRange))
+        return;
+
+    auto portRange = String::fromLatin1(udpPortsRange);
+    priv->preferences->setWebRTCUDPPortRange(portRange);
+    priv->webrtcUDPPortsRange = portRange.utf8();
+    g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_WEBRTC_UDP_PORTS_RANGE]);
+#else
+    UNUSED_PARAM(udpPortsRange);
+#endif
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -4452,7 +4452,7 @@ void webkit_settings_set_enable_ice_candidate_filtering(WebKitSettings* settings
 const gchar*
 webkit_settings_get_webrtc_udp_ports_range(WebKitSettings* settings)
 {
-    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), nullptr);
 #if ENABLE(WEB_RTC)
     return settings->priv->webrtcUDPPortsRange.data();
 #else

--- a/Source/WebKit/UIProcess/API/gtk/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitSettings.h
@@ -522,6 +522,20 @@ WEBKIT_API void
 webkit_settings_set_enable_webrtc                              (WebKitSettings *settings,
                                                                 gboolean enabled);
 
+WEBKIT_API gboolean
+webkit_settings_get_disable_web_security                       (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_disable_web_security                       (WebKitSettings *settings,
+                                                                gboolean        disabled);
+
+WEBKIT_API const gchar*
+webkit_settings_get_webrtc_udp_ports_range                     (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_webrtc_udp_ports_range                     (WebKitSettings *settings,
+                                                                const gchar    *udp_port_range);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
@@ -534,6 +534,13 @@ WEBKIT_API void
 webkit_settings_set_enable_ice_candidate_filtering             (WebKitSettings *settings,
                                                                 gboolean        enabled);
 
+WEBKIT_API const gchar*
+webkit_settings_get_webrtc_udp_ports_range                     (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_webrtc_udp_ports_range                     (WebKitSettings *settings,
+                                                                const gchar    *udp_port_range);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -387,6 +387,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     g_assert_cmpstr("", ==, webkit_settings_get_webrtc_udp_ports_range(settings));
     webkit_settings_set_webrtc_udp_ports_range(settings, "20000:30000");
     g_assert_cmpstr("20000:30000", ==, webkit_settings_get_webrtc_udp_ports_range(settings));
+    webkit_settings_set_webrtc_udp_ports_range(settings, "20000:0");
+    g_assert_cmpstr("20000:0", ==, webkit_settings_get_webrtc_udp_ports_range(settings));
+    webkit_settings_set_webrtc_udp_ports_range(settings, "0:20000");
+    g_assert_cmpstr("0:20000", ==, webkit_settings_get_webrtc_udp_ports_range(settings));
 #endif
 
     g_object_unref(G_OBJECT(settings));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -383,6 +383,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     webkit_settings_set_disable_web_security(settings, TRUE);
     g_assert_true(webkit_settings_get_disable_web_security(settings));
 
+#if ENABLE(WEB_RTC)
+    g_assert_cmpstr("", ==, webkit_settings_get_webrtc_udp_ports_range(settings));
+    webkit_settings_set_webrtc_udp_ports_range(settings, "20000:30000");
+    g_assert_cmpstr("20000:30000", ==, webkit_settings_get_webrtc_udp_ports_range(settings));
+#endif
+
     g_object_unref(G_OBJECT(settings));
 }
 


### PR DESCRIPTION
Allow to setup webrtc peer port range. Possible in two ways:
(1) WEBKIT_WEBRTC_PEER_PORT_RANGE env variable
(2) "webrtc-udp-ports-range" property

Apply upstream changes.

Sample validation build: https://jenkins.onemw.net/job/EngineeringBuild/32086/
Injects:
https://gerrit.onemw.net/c/meta-lgi-wpe/+/120637/4/
https://gerrit.onemw.net/c/meta-lgi-om/+/119952/4/