### PR TITLE
ARRISEOS-46055 no shrinkFootprintWhenIdle

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1042,10 +1042,6 @@ void WebProcess::isJITEnabled(CompletionHandler<void(bool)>&& completionHandler)
 
 void WebProcess::garbageCollectJavaScriptObjects()
 {
-    {
-        JSLockHolder lock(commonVM());
-        commonVM().shrinkFootprintWhenIdle();
-    }
     GCController::singleton().garbageCollectNow();
 }
 


### PR DESCRIPTION
Do not call shrinkFootprintWhenIdle on forced GC since this has the effect of increasing app load times.