### PR TITLE
[ARRISEOS-46397] Fix hang in webaudio

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -449,7 +449,6 @@ static GstStateChangeReturn webKitWebAudioSrcChangeState(GstElement* element, Gs
     case GST_STATE_CHANGE_PAUSED_TO_READY:
         {
             Locker locker { priv->dispatchLock };
-            priv->dispatchDone = false;
             priv->dispatchCondition.notifyAll();
         }
         gst_buffer_pool_set_flushing(priv->pool.get(), TRUE);


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=283357

Reviewed by Philippe Normand.

During a PAUSED_TO_READY state change, there is a race condition between webKitWebAudioSrcRenderAndPushFrames setting dispatchDone true, and the state change resetting it to false, so that the renderer thread will block on dispatchCondition.

To fix this, the state transition no longer sets dispatchDone to false, which is already done on every renderer thread entry.

Original author: Marcin Mielczarczyk <marcin.mielczarczyk@redembedded.com>
See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1426

* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp: (webKitWebAudioSrcChangeState):

Canonical link: https://commits.webkit.org/286797@main