### PR TITLE
[ONEM-29845] - changes from upstream to support mp2t for running sample app for shaka

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -231,6 +231,7 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::Element
         }
     }
 
+    shouldCheckHardwareClassifier = CheckHardwareClassifier::Yes;
     if (shouldCheckHardwareClassifier == CheckHardwareClassifier::Yes) {
         for (GList* factories = candidates; factories; factories = g_list_next(factories)) {
             auto* factory = reinterpret_cast<GstElementFactory*>(factories->data);
@@ -439,7 +440,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         { ElementFactories::Type::AudioDecoder, "audio/x-eac3", { "audio/x-ac3"_s },  { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-flac", { "audio/x-flac"_s, "audio/flac"_s }, {"x-flac"_s, "flac"_s } },
         { ElementFactories::Type::VideoDecoder, "video/mpeg", { }, { "mp2v"_s } },
-        { ElementFactories::Type::Demuxer, "video/mpegts", { "video/mp2t"_s }, { } },
+        { ElementFactories::Type::Demuxer, "video/mpegts", { "video/mpegts"_s, "video/mp2t"_s }, { } },
     };
     fillMimeTypeSetFromCapsMapping(factories, mseCompatibleMapping);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -149,6 +149,11 @@ AppendPipeline::AppendPipeline(SourceBufferPrivateGStreamer& sourceBufferPrivate
     } else if (type.endsWith("webm"_s)) {
         m_demux = makeGStreamerElement("matroskademux", nullptr);
         m_typefind = makeGStreamerElement("identity", nullptr);
+    } else if (type.endsWith("mp2t"_s) || type.endsWith("mpegts"_s)) {
+       // INFO_LOG(LOGIDENTIFIER, "mp2t/mpegts support in MSE is experimental");
+        GST_INFO_OBJECT(m_playerPrivate->pipeline(), "mp2t/mpegts support in MSE is experimental");
+        m_demux = makeGStreamerElement("tsdemux", nullptr);
+        m_typefind = makeGStreamerElement("identity", nullptr);
     } else if (type == "audio/mpeg"_s) {
         m_demux = makeGStreamerElement("identity", nullptr);
         m_typefind = makeGStreamerElement("typefind", nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -60,7 +60,13 @@ namespace WebCore {
 bool SourceBufferPrivateGStreamer::isContentTypeSupported(const ContentType& type)
 {
     const auto& containerType = type.containerType();
-    return containerType == "audio/mpeg"_s || containerType.endsWith("mp4"_s) || containerType.endsWith("aac"_s) || containerType.endsWith("webm"_s);
+    #if !RELEASE_LOG_DISABLED || !defined(GST_DISABLE_GST_DEBUG)
+    if (containerType.endsWith("mp2t"_s)) {
+       // INFO_LOG(LOGIDENTIFIER, "mp2t/mpegts support in MSE is experimental");
+        GST_INFO("mp2t/mpegts support in MSE is experimental");
+    }
+#endif
+    return containerType == "audio/mpeg"_s || containerType.endsWith("mp4"_s) || containerType.endsWith("aac"_s) || containerType.endsWith("webm"_s) || containerType.endsWith("mp2t"_s);
 }
 
 Ref<SourceBufferPrivateGStreamer> SourceBufferPrivateGStreamer::create(MediaSourcePrivateGStreamer* mediaSource, const ContentType& contentType, MediaPlayerPrivateGStreamerMSE& playerPrivate)

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -1485,7 +1485,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             "enable-media-capabilities",
             _("Enable MediaCapabilities"),
             _("Whether MediaCapabilities should be enabled."),
-            FALSE,
+            TRUE,
             readWriteConstructParamFlags);
 
     /**


### PR DESCRIPTION
Created a Sample App for Hlsjs PlayReady 4.0. The sample app is working fine in Microsoft Edge Browser. But in Sagemcom its showing Error loading playback.
So tried whitelisting url using following steps:

    ssh into Sagemcom and vi /etc/WPEFramework/plugins/WebKitBrowser.json
    added "mixedcontentwhitelist":"[{"origin":"https://.", "domain":["http://"]}, {"origin":"http://.", "domain":["http://"]},{"origin":"http://.", "domain":["https://*"]}]",
    Restarted wpeframework: systemctl restart wpeframework
    Using thunder UI I have ran the sample app

After whitelisting also its showing Error loading playback.