### PR TITLE
[ONEM-36631]-During seek flow avoid play call before finishseek call

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3212,6 +3212,10 @@ void HTMLMediaElement::seekWithTolerance(const MediaTime& inTime, const MediaTim
     refreshCachedTime();
     MediaTime now = currentMediaTime();
 
+    // Needed to detect a special case in updatePlayState().
+    if (now >= durationMediaTime())
+        m_seekAfterPlaybackEnded = true;
+
     // 3 - If the element's seeking IDL attribute is true, then another instance of this algorithm is
     // already running. Abort that other instance of the algorithm without waiting for the step that
     // it is running to complete.
@@ -3383,6 +3387,8 @@ void HTMLMediaElement::finishSeek()
 #endif
     if (wasPlayingBeforeSeeking)
         playInternal();
+
+    m_seekAfterPlaybackEnded = false;
 }
 
 HTMLMediaElement::ReadyState HTMLMediaElement::readyState() const
@@ -3804,8 +3810,10 @@ void HTMLMediaElement::playInternal()
     if (!m_player || m_networkState == NETWORK_EMPTY)
         selectMediaResource();
 
-    if (endedPlayback())
+    if (endedPlayback()) {
+        m_seekAfterPlaybackEnded = true;
         seekInternal(MediaTime::zeroTime());
+    }
 
     if (m_mediaController)
         m_mediaController->bringElementUpToSpeed(*this);
@@ -5765,7 +5773,17 @@ void HTMLMediaElement::updatePlayState()
     if (shouldBePlaying) {
         invalidateCachedTime();
 
-        if (playerPaused) {
+        // Play is always allowed, except when seeking (to avoid unpausing the video by mistake until the
+        // target time is reached). However, there are some exceptional situations when we allow playback
+        // during seek. This is because GStreamer-based implementation have a design limitation that doesn't
+        // allow initial seeks (seeking before going to playing state), and these exceptions make things
+        // work for those platforms.
+        bool isLooping = loop() && m_lastSeekTime == MediaTime::zeroTime();
+        bool playExceptionsWhenSeeking = m_seeking && (m_firstTimePlaying
+            || isLooping || m_isResumingPlayback || m_seekAfterPlaybackEnded);
+        bool allowPlay = !m_seeking || playExceptionsWhenSeeking;
+
+        if (playerPaused && allowPlay) {
             mediaSession().clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.
@@ -8110,8 +8128,11 @@ void HTMLMediaElement::resumeAutoplaying()
 void HTMLMediaElement::mayResumePlayback(bool shouldResume)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "paused = ", paused());
-    if (paused() && shouldResume)
+    if (paused() && shouldResume) {
+        m_isResumingPlayback = true;
         play();
+        m_isResumingPlayback = false;
+    }
 }
 
 String HTMLMediaElement::mediaSessionTitle() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1162,6 +1162,8 @@ private:
     bool m_shouldAudioPlaybackRequireUserGesture : 1;
     bool m_shouldVideoPlaybackRequireUserGesture : 1;
     bool m_volumeLocked : 1;
+    bool m_isResumingPlayback : 1 { false };
+    bool m_seekAfterPlaybackEnded : 1 { false };
 
     AutoplayEventPlaybackState m_autoplayEventPlaybackState { AutoplayEventPlaybackState::None };
 


### PR DESCRIPTION
Change provided by the upstream for the following issue :

Issue : 
Sometimes state=play is observed in between state=seek_start and state=seek_done

Reproduction rate:
Atleast once in 10 attempts 

Steps to Reproduce & Results : 

1. Ensure that reportingPeriodicity is set to 1 for gstreamer AVPipelineReport in main config file (vi /usr/share/lgias/data/configuration/main.json)
 "gstreamer": {
      "AVPipelineReport": {
        "reportingPeriodicity": 1
      }
      
2. Open CNN and start to play some video

3. Do seek using seek button shown on UI and then Run following command on the box
sed 's/},{/}\n\n{/g' /usr/share/lgias/data/usage-collector/buffers/buffer* | grep "AVPipelineReport.*wpe"
Expected Result :

{"type":"AVPipelineReport","v":1,"report_type":"info","state":"pause","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x149eb6 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=120 drops=0 errors=0 overflows=0\nDisplay: displayed=91 drops=29 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x14ad5c pts_stc_diff=-83 pts_offset=0x596 errors=0\nDecode: frames decoded=146 errors=0\n","additional_info":""},"ts":1724395640030} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"pause","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x149eb6 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=120 drops=0 errors=0 overflows=0\nDisplay: displayed=91 drops=29 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x14ad5c pts_stc_diff=-83 pts_offset=0x596 errors=0\nDecode: frames decoded=146 errors=0\n","additional_info":""},"ts":1724395640030} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_start","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x149eb6 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=120 drops=0 errors=0 overflows=0\nDisplay: displayed=91 drops=29 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x14ad5c pts_stc_diff=-83 pts_offset=0x596 errors=0\nDecode: frames decoded=146 errors=0\n","additional_info":"seek_from:30.093333, seek_to:39.000000"},"ts":1724395640544} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_start","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x149eb6 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=120 drops=0 errors=0 overflows=0\nDisplay: displayed=91 drops=29 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x14ad5c pts_stc_diff=-83 pts_offset=0x596 errors=0\nDecode: frames decoded=146 errors=0\n","additional_info":"seek_from:30.093333, seek_to:39.000000"},"ts":1724395640545} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_done","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":"seek_to:39.000000"},"ts":1724395641593} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_done","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":"seek_to:39.000000"},"ts":1724395641594} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"play","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":""},"ts":1724395641612} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"play","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=117 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":""},"ts":1724395641612}


Actual Result :

{"type":"AVPipelineReport","v":1,"report_type":"info","state":"pause","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x1c285f pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=89 drops=0 errors=0 overflows=0\nDisplay: displayed=61 drops=28 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x1c311c pts_stc_diff=-3 pts_offset=0x596 errors=0\nDecode: frames decoded=96 errors=0\n","additional_info":""},"ts":1724395644012} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"pause","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x1c285f pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=89 drops=0 errors=0 overflows=0\nDisplay: displayed=61 drops=28 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x1c311c pts_stc_diff=-3 pts_offset=0x596 errors=0\nDecode: frames decoded=96 errors=0\n","additional_info":""},"ts":1724395644012}, {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_start","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x1c285f pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=89 drops=0 errors=0 overflows=0\nDisplay: displayed=61 drops=28 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x1c311c pts_stc_diff=-3 pts_offset=0x596 errors=0\nDecode: frames decoded=96 errors=0\n","additional_info":"seek_from:41.026667, seek_to:50.000000"},"ts":1724395644532} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_start","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x1c285f pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=89 drops=0 errors=0 overflows=0\nDisplay: displayed=61 drops=28 errors=0 underflows=0\nAudio:\nTSM: enabled pts=0x1c311c pts_stc_diff=-3 pts_offset=0x596 errors=0\nDecode: frames decoded=96 errors=0\n","additional_info":"seek_from:41.026667, seek_to:50.000000"},"ts":1724395644533} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"play","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":""},"ts":1724395645649} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"play","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":""},"ts":1724395645650} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_done","owner":"wpe","pipeline_info":{"source":"audio/x-aac","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":"seek_to:50.000000"},"ts":1724395645827} {"type":"AVPipelineReport","v":1,"report_type":"info","state":"seek_done","owner":"wpe","pipeline_info":{"source":"video/x-h264","drm":"None","framerate":"30","hdr":"None","resolution":"1080","decoder_statistics":"Video:\nTSM: enabled pts=0x0 pts_stc_diff=140 pts_offset=0x1198 errors=0\nDecode: decoded=0 drops=0 errors=0 overflows=0\nDisplay: displayed=0 drops=0 errors=0 underflows=0\nAudio:\n","additional_info":"seek_to:50.000000"},"ts":1724395645827},