### PR TITLE
ARRISAPOL-3614 wpe: fix in GstState handling

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -955,7 +955,10 @@ bool MediaPlayerPrivateGStreamer::changePipelineState(GstState newState)
     GstState currentState, pending;
 
     gst_element_get_state(m_pipeline.get(), &currentState, &pending, 0);
-    if (currentState == newState || pending == newState) {
+
+    // the pipeline can be in the process of switching to another state (pending != GST_STATE_VOID_PENDING)
+    // in such case we should apply newState even if at the moment it is equal to currentState (this will soon change)
+    if ( (currentState == newState && pending == GST_STATE_VOID_PENDING) || pending == newState) {
         GST_DEBUG_OBJECT(pipeline(), "Rejected state change to %s from %s with %s pending", gst_element_state_get_name(newState),
             gst_element_state_get_name(currentState), gst_element_state_get_name(pending));
         return true;


### PR DESCRIPTION
MediaPlayerPrivateGStreamer::changePipelineState assumes that when pipeline state change is requested, and the requested state is same as current state, that request can be rejected. What was not taken into account is that even if newState == currentState, there might still be some other state pending, and the pipeline state might still need to be updated in such case.