### PR TITLE
ARRISAPP-1229: WPEFramework crashed in browser deactivation

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -423,6 +423,9 @@ void AuxiliaryProcessProxy::checkForResponsiveness(CompletionHandler<void()>&& r
 {
     startResponsivenessTimer(useLazyStop);
     sendWithAsyncReply(Messages::AuxiliaryProcess::MainThreadPing(), [weakThis = WeakPtr { *this }, responsivenessHandler = WTFMove(responsivenessHandler)]() mutable {
+        if (!weakThis || !weakThis->hasConnection() || !weakThis->connection()->isValid())
+            return;
+
         // Schedule an asynchronous task because our completion handler may have been called as a result of the AuxiliaryProcessProxy
         // being in the middle of destruction.
         RunLoop::main().dispatch([weakThis = WTFMove(weakThis), responsivenessHandler = WTFMove(responsivenessHandler)]() mutable {


### PR DESCRIPTION
Crashes reported with WPEFramework::Plugin::WebKitImplementation::DeactivateBrowser() in callstack.

This change is to fix the regression(hang/reboot) observed with PR https://github.com/LibertyGlobal/rdkservices/pull/429 when WPEWebProcess was unresponsive for extended period

Do not dispatch responsiveness handler in the middle of destruction of UI Process.

Actual results:
crash reported

Expected results:
no crashes observed