### PR TITLE
[ONEM-36631]- Adding custom logs

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -432,6 +432,7 @@ bool MediaPlayerPrivateGStreamer::isPipelineWaitingPreroll() const
 
 void MediaPlayerPrivateGStreamer::play()
 {
+    fprintf(stderr,"Gowthami-play()\n");	
     if (isMediaStreamPlayer()) {
         m_pausedTime = MediaTime::invalidTime();
         if (m_startTime.isInvalid())
@@ -463,6 +464,7 @@ void MediaPlayerPrivateGStreamer::play()
 
 void MediaPlayerPrivateGStreamer::pause()
 {
+	fprintf(stderr,"Gowthami-pause()\n");
     if (isMediaStreamPlayer())
         m_pausedTime = currentMediaTime();
 
@@ -564,6 +566,7 @@ bool MediaPlayerPrivateGStreamer::doSeek(const MediaTime& position, float rate, 
 
 void MediaPlayerPrivateGStreamer::seek(const MediaTime& mediaTime)
 {
+	fprintf(stderr,"Gowthami-seek start\n");
     if (!m_pipeline || m_didErrorOccur || isMediaStreamPlayer())
         return;
 
@@ -2582,6 +2585,7 @@ void MediaPlayerPrivateGStreamer::purgeOldDownloadFiles(const String& downloadFi
 
 void MediaPlayerPrivateGStreamer::finishSeek()
 {
+	fprintf(stderr,"Gowthami-finishseek\n");
     GST_DEBUG_OBJECT(pipeline(), "[Seek] seeked to %s", toString(m_seekTime).utf8().data());
     m_telemetry.reportPlaybackState(Telemetry::IReport::AVPipelineState::SEEK_DONE, "seek_to:"+std::to_string(m_seekTime.toDouble()));
 


### PR DESCRIPTION
During the video playback ideally states must flow as play -> pause -> seek_start -> seek_done -> play but randomly it is observed that play event is being sent before finishing the seek (seek_done) i.e, play -> pause -> seek_start -> play -> seek_done 