### PR TITLE
[ONEM-38081]: Increased memory consumption of WebProcess during regul…

### DIFF
--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -96,7 +96,7 @@ void NetworkResourcesData::ResourceData::appendData(const SharedBuffer& data)
     m_dataBuffer.append(data);
 }
 
-unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
+void NetworkResourcesData::ResourceData::decodeDataToContent()
 {
     ASSERT(!hasContent());
 
@@ -111,7 +111,7 @@ unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
         m_content = base64EncodeToString(buffer->data(), dataLength);
     }
 
-    return m_content.sizeInBytes() - dataLength;
+    ASSERT(m_content.sizeInBytes() >= buffer->size());
 }
 
 NetworkResourcesData::NetworkResourcesData()
@@ -200,7 +200,7 @@ void NetworkResourcesData::setResourceContent(const String& requestId, const Str
         // We can not be sure that we didn't try to save this request data while it was loading, so remove it, if any.
         if (resourceData->hasContent() || resourceData->hasData())
             m_contentSize -= resourceData->removeContent();
-        m_requestIdsDeque.append(requestId);
+        m_requestIdsDeque.appendOrMoveToLast(requestId);
         resourceData->setContent(content, base64Encoded);
         m_contentSize += dataLength;
     }
@@ -236,7 +236,7 @@ NetworkResourcesData::ResourceData const* NetworkResourcesData::maybeAddResource
         return resourceData;
 
     if (ensureFreeSpace(data.size()) && !resourceData->isContentEvicted()) {
-        m_requestIdsDeque.append(requestId);
+        m_requestIdsDeque.appendOrMoveToLast(requestId);
         resourceData->appendData(data);
         m_contentSize += data.size();
     }
@@ -253,10 +253,18 @@ void NetworkResourcesData::maybeDecodeDataToContent(const String& requestId)
     if (!resourceData->hasData())
         return;
 
-    m_contentSize += resourceData->decodeDataToContent();
-    size_t dataLength = resourceData->content().sizeInBytes();
-    if (dataLength > m_maximumSingleResourceContentSize)
-        m_contentSize -= resourceData->evictContent();
+    auto byteCount = resourceData->dataLength();
+    m_contentSize -= byteCount;
+
+    resourceData->decodeDataToContent();
+    byteCount = resourceData->content().sizeInBytes();
+    if (byteCount > m_maximumSingleResourceContentSize) {
+        resourceData->evictContent();
+        return;
+    }
+
+    if (ensureFreeSpace(byteCount) && !resourceData->isContentEvicted())
+        m_contentSize += byteCount;
 }
 
 void NetworkResourcesData::addCachedResource(const String& requestId, CachedResource* cachedResource)
@@ -313,19 +321,23 @@ Vector<String> NetworkResourcesData::removeCachedResource(CachedResource* cached
 
 void NetworkResourcesData::clear(std::optional<String> preservedLoaderId)
 {
-    m_requestIdsDeque.clear();
-    m_contentSize = 0;
-
-    if (!preservedLoaderId)
+    if (!preservedLoaderId) {
         m_requestIdToResourceDataMap.clear();
-    else {
-        Vector<String> keysToRemove;
-        for (auto& [key, value] : m_requestIdToResourceDataMap) {
-            if (value->loaderId() != *preservedLoaderId)
-                keysToRemove.append(key);
+        m_requestIdsDeque.clear();
+        m_contentSize = 0;
+        return;
+    }
+
+    for (auto&& requestId : std::exchange(m_requestIdsDeque, { })) {
+        auto resourceData = resourceDataForRequestId(requestId);
+        if (!resourceData)
+            continue;
+        if (resourceData->loaderId() == *preservedLoaderId)
+            m_requestIdsDeque.add(requestId);
+        else {
+            m_contentSize -= resourceData->evictContent();
+            m_requestIdToResourceDataMap.remove(requestId);
         }
-        for (auto& keyToRemove : keysToRemove)
-            m_requestIdToResourceDataMap.remove(keyToRemove);
     }
 }
 
@@ -357,6 +369,7 @@ bool NetworkResourcesData::ensureFreeSpace(size_t size)
     if (size > m_maximumResourcesContentSize)
         return false;
 
+    ASSERT(m_maximumResourcesContentSize >= m_contentSize);
     while (size > m_maximumResourcesContentSize - m_contentSize) {
         String requestId = m_requestIdsDeque.takeFirst();
         ResourceData* resourceData = resourceDataForRequestId(requestId);

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -31,7 +31,7 @@
 
 #include "InspectorPageAgent.h"
 #include "SharedBuffer.h"
-#include <wtf/Deque.h>
+#include <wtf/ListHashSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
@@ -109,7 +109,7 @@ public:
         bool hasData() const;
         size_t dataLength() const;
         void appendData(const SharedBuffer&);
-        unsigned decodeDataToContent();
+        void decodeDataToContent();
 
         String m_requestId;
         String m_loaderId;
@@ -156,7 +156,7 @@ private:
     void ensureNoDataForRequestId(const String& requestId);
     bool ensureFreeSpace(size_t);
 
-    Deque<String> m_requestIdsDeque;
+    ListHashSet<String> m_requestIdsDeque;
     MemoryCompactRobinHoodHashMap<String, std::unique_ptr<ResourceData>> m_requestIdToResourceDataMap;
     size_t m_contentSize { 0 };
     size_t m_maximumResourcesContentSize;


### PR DESCRIPTION
…ar video playback with WebInspector open

This fix is for OOM crash seen for regular playback apps like EuroNews.
Changes provided by upstream for OOM issue : https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/2b42028d47edc875f65b34b30e2841c27bd0fa55

Scenario to reproduce

- Start regular playback app, Eg: EuroNews
- Open WebInspector
- Play video
- Notice the memory consumption

OOM crash is not observed for 2-3hrs of EuroNews Playback.