### PR TITLE
ARRISEOS-46397: Fix 'offline renderer' thread cleanup

### DIFF
--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -86,10 +86,6 @@ void OfflineAudioDestinationNode::uninitialize()
         return;
 
     if (m_startedRendering) {
-        if (m_renderThread) {
-            m_renderThread->waitForCompletion();
-            m_renderThread = nullptr;
-        }
         if (auto* workletProxy = context().audioWorklet().proxy()) {
             BinarySemaphore semaphore;
             workletProxy->postTaskForModeToWorkletGlobalScope([&semaphore](ScriptExecutionContext&) mutable {
@@ -97,6 +93,11 @@ void OfflineAudioDestinationNode::uninitialize()
             }, WorkerRunLoop::defaultMode());
             semaphore.wait();
         }
+    }
+
+    if (m_renderThread.get()) {
+        m_renderThread->waitForCompletion();
+        m_renderThread = nullptr;
     }
 
     AudioNode::uninitialize();


### PR DESCRIPTION
Offline renderer thread in most of the cases doesn't clean up its resources. Thread should be joined on every exit, not only when rendering process is in progress.
This problem was detected during webaudio testing which revealed memory leakage.