### PR TITLE
[ONEM-39318]: Reverting the upstream changes for avoiding the play() …

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3212,10 +3212,6 @@ void HTMLMediaElement::seekWithTolerance(const MediaTime& inTime, const MediaTim
     refreshCachedTime();
     MediaTime now = currentMediaTime();
 
-    // Needed to detect a special case in updatePlayState().
-    if (now >= durationMediaTime())
-        m_seekAfterPlaybackEnded = true;
-
     // 3 - If the element's seeking IDL attribute is true, then another instance of this algorithm is
     // already running. Abort that other instance of the algorithm without waiting for the step that
     // it is running to complete.
@@ -3388,7 +3384,6 @@ void HTMLMediaElement::finishSeek()
     if (wasPlayingBeforeSeeking)
         playInternal();
 
-    m_seekAfterPlaybackEnded = false;
 }
 
 HTMLMediaElement::ReadyState HTMLMediaElement::readyState() const
@@ -3810,10 +3805,8 @@ void HTMLMediaElement::playInternal()
     if (!m_player || m_networkState == NETWORK_EMPTY)
         selectMediaResource();
 
-    if (endedPlayback()) {
-        m_seekAfterPlaybackEnded = true;
+    if (endedPlayback()) 
         seekInternal(MediaTime::zeroTime());
-    }
 
     if (m_mediaController)
         m_mediaController->bringElementUpToSpeed(*this);
@@ -5776,17 +5769,7 @@ void HTMLMediaElement::updatePlayState()
     if (shouldBePlaying) {
         invalidateCachedTime();
 
-        // Play is always allowed, except when seeking (to avoid unpausing the video by mistake until the
-        // target time is reached). However, there are some exceptional situations when we allow playback
-        // during seek. This is because GStreamer-based implementation have a design limitation that doesn't
-        // allow initial seeks (seeking before going to playing state), and these exceptions make things
-        // work for those platforms.
-        bool isLooping = loop() && m_lastSeekTime == MediaTime::zeroTime();
-        bool playExceptionsWhenSeeking = m_seeking && (m_firstTimePlaying
-            || isLooping || m_isResumingPlayback || m_seekAfterPlaybackEnded);
-        bool allowPlay = !m_seeking || playExceptionsWhenSeeking;
-
-        if (playerPaused && allowPlay) {
+        if (playerPaused) {
             mediaSession().clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.
@@ -8131,11 +8114,8 @@ void HTMLMediaElement::resumeAutoplaying()
 void HTMLMediaElement::mayResumePlayback(bool shouldResume)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "paused = ", paused());
-    if (paused() && shouldResume) {
-        m_isResumingPlayback = true;
+    if (paused() && shouldResume) 
         play();
-        m_isResumingPlayback = false;
-    }
 }
 
 String HTMLMediaElement::mediaSessionTitle() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1162,8 +1162,6 @@ private:
     bool m_shouldAudioPlaybackRequireUserGesture : 1;
     bool m_shouldVideoPlaybackRequireUserGesture : 1;
     bool m_volumeLocked : 1;
-    bool m_isResumingPlayback : 1 { false };
-    bool m_seekAfterPlaybackEnded : 1 { false };
 
     AutoplayEventPlaybackState m_autoplayEventPlaybackState { AutoplayEventPlaybackState::None };
 


### PR DESCRIPTION
…during seek operation

The changes are reverted in upstream WPE 2.38
https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/78ce372adae0cf7f80730fe7432a03b12ee8f80a

So, same changes are taken in our branch.
