### PR TITLE
[ARRISAPOL-3635]: [WPE 2.38]: Progress bar is fluctuating while performing seek in Deezer app

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -553,7 +553,7 @@ bool MediaPlayerPrivateGStreamer::doSeek(const MediaTime& position, float rate, 
             quirksManager.resetBufferingPercentage(this, 0);
 
         // Make sure that m_isBuffering is set to true, so that when buffering completes it's set to false again and playback resumes.
-        updateBufferingStatus(GST_BUFFERING_STREAM, 0.0, true);
+        updateBufferingStatus(GST_BUFFERING_STREAM, 0.0, true, false);
         changePipelineState(GST_STATE_PAUSED);
     }
 
@@ -2242,7 +2242,7 @@ void MediaPlayerPrivateGStreamer::updateMaxTimeLoaded(double percentage)
     GST_DEBUG_OBJECT(pipeline(), "[Buffering] Updated maxTimeLoaded: %s", toString(m_maxTimeLoaded).utf8().data());
 }
 
-void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, double percentage, bool resetHistory)
+void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, double percentage, bool resetHistory, bool shouldUpdateStates)
 {
     m_wasBuffering = m_isBuffering;
     m_previousBufferingPercentage = m_bufferingPercentage;
@@ -2310,7 +2310,8 @@ void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, d
         m_previousBufferingPercentage = m_bufferingPercentage;
     }
     updateMaxTimeLoaded(percentage);
-    updateStates();
+    if (shouldUpdateStates)
+        updateStates();
     GST_TRACE("[Buffering] Settled results: m_wasBuffering: %s, m_isBuffering: %s, m_previousBufferingPercentage: %d, m_bufferingPercentage: %d",
         boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering), m_previousBufferingPercentage, m_bufferingPercentage);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -543,7 +543,7 @@ private:
 
     virtual void updateDownloadBufferingFlag();
     void processBufferingStats(GstMessage*);
-    void updateBufferingStatus(GstBufferingMode, double percentage, bool resetHistory = false);
+    void updateBufferingStatus(GstBufferingMode, double percentage, bool resetHistory = false, bool shouldUpdateStates = true);
     void updateMaxTimeLoaded(double percentage);
 
 #if USE(GSTREAMER_MPEGTS)


### PR DESCRIPTION
Description:
While performing seek, progress bar is fluctuating before going to expected position

Severity:
Major (P2)

Replication path/steps:
- open deezer app
- Play some podcast and perform seek 

Actual results:
progress bar is fluctuating

Expected results:
Progress bar should work as expected

Frequency (percentage):
100%

Workaround:
<e.g. channel tune, power cycle, ..>

SW version& HW Platform:
VIP7002W-mon-dbg-06.04-000-aa-AL-20250120210000-un000

Test environment:
Labci