### PR TITLE
[ARRISEOS-47239]: Cloned from Apple Radar 119814367: Mute functionality not working on video element

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1752,6 +1752,10 @@ void MediaPlayerPrivateGStreamer::setVolume(float volume)
 
     GST_DEBUG_OBJECT(pipeline(), "Setting volume: %f", volume);
     gst_stream_volume_set_volume(m_volumeElement.get(), GST_STREAM_VOLUME_FORMAT_LINEAR, static_cast<double>(volume));
+    
+    bool audioMuted = (volume == 0) ? true : false;
+    g_object_set(m_volumeElement.get(), "mute", static_cast<gboolean>(audioMuted), nullptr);
+
     configureMediaStreamAudioTracks();
 }
 


### PR DESCRIPTION
EXTERNAL: Liberty Global: Mute functionality not working on video element
Created by Armand Adams on 18 December 2023 at 16:01
Edited by Armand Adams on 18 December 2023 at 16:01

Reason for clone: Cloning to external for partner review.
Summary: Mute functionality is broken on the video element causing Audio during Trickplay as well as the setting for muting audio on auto play videos to not work. We need the partner to investigate this.

Steps To Reproduce: 1. Launch App 2. Play Elephant Queen 3. Trickplay
ACTUAL: Audio heard during Trickplay
EXPECTED: No audio heard during Trickplay

Steps To Reproduce: 1. Launch ATV+ app, 2. Navigate to Settings tab, 3. scroll down to “Autoplay Video Sound” and set toggle to OFF, 4. Navigate to TV+ tab 5. Allow background video to play on the epic stage
ACTUAL: Video sound for background trailers remains ON when Autoplay Video Sound setting is set to OFF
EXPECTED: Video sound for background trailers is off when Autoplay Video Sound setting is set to OFF

3rd case:
- Play the any content.
- run the below command in web inspector console.
-document.querySelector("video").volume = 0 to mute the audio
- document.querySelector("video").volume = 1 to unmute the audio