### PR TITLE
[ONEM-32713] Resize wayland surfaces when painting suspended

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -140,12 +140,17 @@ void ThreadedCompositor::suspend()
 
 void ThreadedCompositor::suspendToTransparent()
 {
+
+    /* with RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING enabled, we always need to go through scheduleUpdate path.
+       suspend() still be called from sceneUpdateFinished */
+#if !ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
     // If we're in nonCompositedWebGL mode, the WebGLRenderingContext will have painted the
     // transparent background. We don't need to do anything besides suspending.
     if (m_nonCompositedWebGLEnabled) {
         suspend();
         return;
     }
+#endif
 
     // When not in nonCompositedWebGL, we need to request a redraw to paint the transparent
     // background, and when the scene is completed, suspend.
@@ -169,6 +174,14 @@ void ThreadedCompositor::resume()
         m_scene->setActive(true);
         m_suspendToTransparentState = SuspendToTransparentState::None;
     });
+#if ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
+    {
+        // need to resize the view on resume
+        Locker locker { m_attributes.lock };
+        m_attributes.needsResize = true;
+    }
+#endif
+
     m_compositingRunLoop->resume();
     m_compositingRunLoop->scheduleUpdate();
 }
@@ -281,9 +294,19 @@ void ThreadedCompositor::renderLayerTree()
     // GL viewport is updated separately, if necessary. This establishes sequencing where
     // everything inside the will-render and did-render scope is done for a constant-sized scene,
     // and similarly all GL operations are done inside that specific scope.
-
+#if !ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
     if (needsResize)
         m_client.resize(viewportSize);
+#else
+    if (needsResize && m_suspendToTransparentState != SuspendToTransparentState::Requested) {
+        m_client.resize(viewportSize);
+    } else if (m_suspendToTransparentState == SuspendToTransparentState::Requested) {
+        // resizing the surfaces, to conserve the memory; going to small (like 1x1) will not properly work
+        // on some platformns, so choosing 16x16 (should only take around 3*1kB in suspended, instead of eg. 3*8MB for HD)
+        constexpr IntSize suspendedSize(16, 16);
+        m_client.resize(suspendedSize);
+    }
+#endif
 
     m_client.willRenderFrame();
 
@@ -300,6 +323,20 @@ void ThreadedCompositor::renderLayerTree()
         m_suspendToTransparentState = SuspendToTransparentState::WaitingForFrameComplete;
 
     m_context->swapBuffers();
+
+#if ENABLE(RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING)
+    if (m_suspendToTransparentState == SuspendToTransparentState::WaitingForFrameComplete) {
+        /*  With triple buffering we normally have 3 sceen buffers. The backing surfaces may only be really
+            resized when they're presented - so we need 3 buffer swaps to make sure all these surfaces
+            are resized to the requested suspendedSize, thus saving the memory in suspend
+            (one swapBuffers is already done above) */
+        for (int i=0; i<2; ++i) {
+            glClearColor(0, 0, 0, 0);
+            glClear(GL_COLOR_BUFFER_BIT);
+            m_context->swapBuffers();
+        }
+    }
+#endif
 
     if (m_scene->isActive())
         m_client.didRenderFrame();

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -97,6 +97,7 @@ uint64_t AcceleratedSurfaceLibWPE::surfaceID() const
 void AcceleratedSurfaceLibWPE::clientResize(const IntSize& size)
 {
     ASSERT(m_backend);
+    m_size = size;
     wpe_renderer_backend_egl_target_resize(m_backend, std::max(1, m_size.width()), std::max(1, m_size.height()));
 }
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -109,6 +109,7 @@ WEBKIT_OPTION_DEFINE(USE_EXTERNAL_HOLEPUNCH "Whether to enable external holepunc
 WEBKIT_OPTION_DEFINE(ENABLE_ACCELERATED_2D_CANVAS "Whether to enable accelerated 2D canvas" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_OIPF_VK "Whether to enable OIPF keys for DAE applications" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(ENABLE_INSTANT_RATE_CHANGE "Whether to enable instant rate change" PRIVATE OFF)
+WEBKIT_OPTION_DEFINE(ENABLE_RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING "Whether to enable resizing of wayland surfaces when painting is suspended" PRIVATE OFF)
 
 # Supported platforms.
 WEBKIT_OPTION_DEFINE(USE_WPEWEBKIT_PLATFORM_WESTEROS "Whether to enable support for the Westeros platform" PUBLIC OFF)


### PR DESCRIPTION
1. [ONEM-32713 AcceleratedSurfaceLibWPE: save size](https://github.com/LibertyGlobal/WPEWebKit/commit/1aaab994c6ebaa76f6d41ca85fd5c75c489c174c)

AcceleratedSurfaceLibWPE::clientResize was disregarding the passed size argument, and still passing current m_size to wpe_renderer_backend_egl_target_resize

2.  [ONEM-32713 resize surfaces at suspendToTransparent](https://github.com/LibertyGlobal/WPEWebKit/commit/26b40d2b5557cf1df92b97e5c314bc0c35f6c83c)

This change adds the mechanism to resize wayland surfaces to 16x16 when painting is suspended (this uses only 1kb, instead of 8mb, for each swapchain surface). It is controlled with comp-time ENABLE_RESIZE_WAYLAND_SURFACES_ON_SUSPEND_PAINTING variable, which by default is disabled.

