### PR TITLE
[ARRISEOS-47345][SOUP] WPENetworkProcess crashed on process exit

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -152,7 +152,10 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)
     setupLogger();
 }
 
-SoupNetworkSession::~SoupNetworkSession() = default;
+SoupNetworkSession::~SoupNetworkSession()
+{
+    soup_session_abort(m_soupSession.get());
+}
 
 void SoupNetworkSession::setupLogger()
 {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=290446

Reviewed by Michael Catanzaro.

To cancel all pending requests before network process exits, we have to abort the current soup session. This will cancell all pending cancellable task in glib-network backends (e.g.: OpenSSL, GnuTLS).

Original author: Volodymyr Ogorodnik()
See: https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1482

* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp: (WebCore::SoupNetworkSession::~SoupNetworkSession):

Canonical link: https://commits.webkit.org/294000@main

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
