### PR TITLE
[ONEM-38081]: Increased memory consumption of WebProcess during regul…

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1000,6 +1000,19 @@ InspectorAttachmentSide:
     WebKit:
       default: 0
 
+InspectorMaximumResourcesContentSize:
+  type: uint32_t
+  status: embedder
+  defaultValue:
+    WebKitLegacy:
+      default: 200
+    WebKit:
+      "PLATFORM(WPE)": 50
+      default: 200
+    WebCore:
+      "PLATFORM(WPE)": 50
+      default: 200
+
 InspectorStartsAttached:
   type: bool
   webcoreBinding: none

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -40,8 +40,7 @@ namespace WebCore {
 
 using namespace Inspector;
 
-static const size_t maximumResourcesContentSize = 200 * 1000 * 1000; // 200MB
-static const size_t maximumSingleResourceContentSize = 50 * 1000 * 1000; // 50MB
+static const unsigned maximumSingleResourceContentSizeMB = 50; // 50MB
 
 NetworkResourcesData::ResourceData::ResourceData(const String& requestId, const String& loaderId)
     : m_requestId(requestId)
@@ -114,9 +113,9 @@ void NetworkResourcesData::ResourceData::decodeDataToContent()
     ASSERT(m_content.sizeInBytes() >= buffer->size());
 }
 
-NetworkResourcesData::NetworkResourcesData()
-    : m_maximumResourcesContentSize(maximumResourcesContentSize)
-    , m_maximumSingleResourceContentSize(maximumSingleResourceContentSize)
+NetworkResourcesData::NetworkResourcesData(uint32_t maximumResourcesContentSize)
+    : m_maximumResourcesContentSize(maximumResourcesContentSize * MB)
+    , m_maximumSingleResourceContentSize(maximumSingleResourceContentSizeMB * MB)
 {
 }
 

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -132,7 +132,7 @@ public:
         WallTime m_responseTimestamp;
     };
 
-    NetworkResourcesData();
+    NetworkResourcesData(uint32_t maximumResourcesContentSize);
     ~NetworkResourcesData();
 
     void resourceCreated(const String& requestId, const String& loaderId, InspectorPageAgent::ResourceType);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -180,12 +180,12 @@ Ref<Protocol::Network::WebSocketFrame> buildWebSocketMessage(const WebSocketFram
 
 } // namespace
 
-InspectorNetworkAgent::InspectorNetworkAgent(WebAgentContext& context)
+InspectorNetworkAgent::InspectorNetworkAgent(WebAgentContext& context, uint32_t maximumResourcesContentSize)
     : InspectorAgentBase("Network"_s, context)
     , m_frontendDispatcher(makeUnique<Inspector::NetworkFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::NetworkBackendDispatcher::create(context.backendDispatcher, this))
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_resourcesData(makeUnique<NetworkResourcesData>())
+    , m_resourcesData(makeUnique<NetworkResourcesData>(maximumResourcesContentSize))
 {
 }
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -137,7 +137,7 @@ public:
     void searchInRequest(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::RequestId&, const String& query, bool caseSensitive, bool isRegex, RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>&);
 
 protected:
-    InspectorNetworkAgent(WebAgentContext&);
+    InspectorNetworkAgent(WebAgentContext&, uint32_t);
 
     virtual Inspector::Protocol::Network::LoaderId loaderIdentifier(DocumentLoader*) = 0;
     virtual Inspector::Protocol::Network::FrameId frameIdentifier(DocumentLoader*) = 0;

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 using namespace Inspector;
 
 PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorClient* client)
-    : InspectorNetworkAgent(context)
+    : InspectorNetworkAgent(context, context.inspectedPage.settings().inspectorMaximumResourcesContentSize())
     , m_inspectedPage(context.inspectedPage)
     , m_client(client)
 {

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 using namespace Inspector;
 
 WorkerNetworkAgent::WorkerNetworkAgent(WorkerAgentContext& context)
-    : InspectorNetworkAgent(context)
+    : InspectorNetworkAgent(context, context.globalScope.settingsValues().inspectorMaximumResourcesContentSize)
     , m_globalScope(context.globalScope)
 {
     ASSERT(context.globalScope.isContextThread());


### PR DESCRIPTION
This fix is for OOM crash seen for DASH/HLS playback apps like BBC iplayer, ITVX,etc.

Changes provided by upstream : https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1484