### PR TITLE
ARRISEOS-47724: Fiit: CS2400 error displayed multiple scenarios

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -263,6 +263,7 @@ void drawPatternToCairoContext(cairo_t* cr, cairo_surface_t* image, const IntSiz
         cairo_rectangle(scaledImageContext.get(), 0, 0, scaledImageSurfaceSize.width(), scaledImageSurfaceSize.height());
         cairo_fill(scaledImageContext.get());
         image = scaledImageSurface.get();
+        cairo_pattern_destroy(pattern.get());
     }
 
     // Due to a limitation in pixman, cairo cannot handle transformation matrices with values bigger than 32768. If the value is


### PR DESCRIPTION
Cherry-pick of - https://github.com/LibertyGlobal/WPEWebKit/pull/502

This is a regression introduced in the upstream commit https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/7d2a4ff147c6862f1cb19d5860f5a1e9a87c8152 (as a fix for [wpe-2.38] Spurious lines in zoomed content https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1324)
On reverting this commit, issue not seen.
In the above commit, there is no corresponding release called for "RefPtr<cairo_pattern_t> pattern = cairo_pattern_create_for_surface(image);"
Calling cairo_pattern_destroy() fixes the issue.