### PR TITLE
ONEM-41470: Downstream cairo memory leak fix

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -239,7 +239,7 @@ void drawPatternToCairoContext(cairo_t* cr, cairo_surface_t* image, const IntSiz
         scaledImageSurface = adoptRef(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, scaledImageSurfaceSize.width(), scaledImageSurfaceSize.height()));
         RefPtr<cairo_t> scaledImageContext = adoptRef(cairo_create(scaledImageSurface.get()));
 
-        RefPtr<cairo_pattern_t> pattern = cairo_pattern_create_for_surface(image);
+        RefPtr<cairo_pattern_t> pattern = adoptRef(cairo_pattern_create_for_surface(image));
         switch (imageInterpolationQuality) {
         case InterpolationQuality::DoNotInterpolate:
         case InterpolationQuality::Low:
@@ -263,7 +263,6 @@ void drawPatternToCairoContext(cairo_t* cr, cairo_surface_t* image, const IntSiz
         cairo_rectangle(scaledImageContext.get(), 0, 0, scaledImageSurfaceSize.width(), scaledImageSurfaceSize.height());
         cairo_fill(scaledImageContext.get());
         image = scaledImageSurface.get();
-        cairo_pattern_destroy(pattern.get());
     }
 
     // Due to a limitation in pixman, cairo cannot handle transformation matrices with values bigger than 32768. If the value is


### PR DESCRIPTION
Reverting fix introduced in LGI's 25Q1 branch (https://github.com/LibertyGlobal/WPEWebKit/commit/a8cf7ec114105974bffe9b3dd67094e003f15460) which was made as part of fixing https://jira.lgi.io/browse/ARRISEOS-47724 and down streaming the upstream fix for the same available at https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1518/commits/f622590df98cdbfa4081a4bbf7494a7c03c5a79e