### PR TITLE
Add initial support for freeze and resume of Page Lifecycle API

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1698,6 +1698,20 @@ PDFPluginEnabled:
     WebKit:
       default: true
 
+PageLifecycleAPIEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Page Lifecycle API"
+  humanReadableDescription: "Enable the Page Lifecycle API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 PageVisibilityBasedProcessSuppressionEnabled:
   type: bool
   webcoreBinding: none

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9245,6 +9245,22 @@ bool Document::lazyImageLoadingEnabled() const
     return m_settings->lazyImageLoadingEnabled() && !m_quirks->shouldDisableLazyImageLoadingQuirk();
 }
 
+// https://wicg.github.io/page-lifecycle/spec.html#freeze-steps
+void Document::freeze()
+{
+    m_frozen = true;
+
+    dispatchEvent(Event::create(eventNames().freezeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+}
+
+// https://wicg.github.io/page-lifecycle/spec.html#resume-steps
+void Document::resume()
+{
+    dispatchEvent(Event::create(eventNames().resumeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+
+    m_frozen = false;
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1695,6 +1695,8 @@ public:
 
     // This should be used over the settings lazy loading image flag due to a quirk, which may occur causing website images to fail to load properly.
     bool lazyImageLoadingEnabled() const;
+    void freeze();
+    void resume();
 
 protected:
     enum ConstructionFlags { Synthesized = 1, NonRenderedPlaceholder = 1 << 1 };
@@ -2227,6 +2229,8 @@ private:
     OrientationNotifier m_orientationNotifier;
     mutable RefPtr<Logger> m_logger;
     RefPtr<StringCallback> m_consoleMessageListener;
+
+    bool m_frozen { false };
 
     static bool hasEverCreatedAnAXObjectCache;
 

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -94,6 +94,9 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
 
     // Non standard: It has been dropped from Blink already.
     RenderingContext? getCSSCanvasContext(DOMString contextId, DOMString name, long width, long height);
+
+    [EnabledBySetting=PageLifecycleAPIEnabled] attribute EventHandler onfreeze;
+    [EnabledBySetting=PageLifecycleAPIEnabled] attribute EventHandler onresume;
 };
 
 enum DocumentReadyState { "loading", "interactive", "complete" };

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -130,6 +130,7 @@ namespace WebCore {
     macro(focusin) \
     macro(focusout) \
     macro(formdata) \
+    macro(freeze) \
     macro(gamepadconnected) \
     macro(gamepaddisconnected) \
     macro(gatheringstatechange) \

--- a/Source/WebCore/page/ActivityState.cpp
+++ b/Source/WebCore/page/ActivityState.cpp
@@ -53,6 +53,7 @@ TextStream& operator<<(TextStream& ts, OptionSet<ActivityState::Flag> flags)
     appendIf(ActivityState::IsLoading, "loading");
     appendIf(ActivityState::IsCapturingMedia, "capturing media");
     appendIf(ActivityState::IsConnectedToHardwareConsole, "attached to hardware console");
+    appendIf(ActivityState::IsFrozen, "frozen");
 
     return ts;
 }

--- a/Source/WebCore/page/ActivityState.h
+++ b/Source/WebCore/page/ActivityState.h
@@ -45,9 +45,10 @@ struct ActivityState {
         IsLoading = 1 << 7,
         IsCapturingMedia = 1 << 8,
         IsConnectedToHardwareConsole = 1 << 9,
+        IsFrozen = 1 << 10,
     };
 
-    static constexpr OptionSet<Flag> allFlags() { return { WindowIsActive, IsFocused, IsVisible, IsVisibleOrOccluded, IsInWindow, IsVisuallyIdle, IsAudible, IsLoading, IsCapturingMedia, IsConnectedToHardwareConsole }; }
+    static constexpr OptionSet<Flag> allFlags() { return { WindowIsActive, IsFocused, IsVisible, IsVisibleOrOccluded, IsInWindow, IsVisuallyIdle, IsAudible, IsLoading, IsCapturingMedia, IsConnectedToHardwareConsole, IsFrozen }; }
 };
 
 enum class ActivityStateForCPUSampling {
@@ -74,7 +75,8 @@ template<> struct EnumTraits<WebCore::ActivityState::Flag> {
         WebCore::ActivityState::Flag::IsAudible,
         WebCore::ActivityState::Flag::IsLoading,
         WebCore::ActivityState::Flag::IsCapturingMedia,
-        WebCore::ActivityState::Flag::IsConnectedToHardwareConsole
+        WebCore::ActivityState::Flag::IsConnectedToHardwareConsole,
+        WebCore::ActivityState::Flag::IsFrozen
     >;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5425,12 +5425,13 @@ webkit_web_view_get_default_content_security_policy(WebKitWebView* webView)
     return webView->priv->defaultContentSecurityPolicy.data();
 }
 
-void webkit_web_view_suspend(WebKitWebView *webView)
+void webkit_web_view_freeze(WebKitWebView *webView)
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.remove(WebCore::ActivityState::IsInWindow);
+    viewStateFlags.add(WebCore::ActivityState::IsFrozen);
     webView->priv->view->setViewState(viewStateFlags);
 }
 
@@ -5440,6 +5441,7 @@ void webkit_web_view_resume(WebKitWebView *webView)
 
     auto viewStateFlags = webView->priv->view->viewState();
     viewStateFlags.add(WebCore::ActivityState::IsInWindow);
+    viewStateFlags.remove(WebCore::ActivityState::IsFrozen);
     webView->priv->view->setViewState(viewStateFlags);
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -105,6 +105,11 @@ bool PageClientImpl::isViewInWindow()
     return m_view.viewState().contains(WebCore::ActivityState::IsInWindow);
 }
 
+bool PageClientImpl::isViewFrozen()
+{
+    return m_view.viewState().contains(WebCore::ActivityState::IsFrozen);
+}
+
 void PageClientImpl::processDidExit()
 {
 }

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -76,6 +76,7 @@ private:
     bool isViewFocused() override;
     bool isViewVisible() override;
     bool isViewInWindow() override;
+    bool isViewFrozen() override;
 
     void processDidExit() override;
     void didRelaunchProcess() override;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
@@ -656,7 +656,7 @@ WEBKIT_API const gchar*
 webkit_web_view_get_default_content_security_policy  (WebKitWebView             *web_view);
 
 WEBKIT_API void
-webkit_web_view_suspend                              (WebKitWebView               *web_view);
+webkit_web_view_freeze                              (WebKitWebView               *web_view);
 
 WEBKIT_API void
 webkit_web_view_resume                               (WebKitWebView               *web_view);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -238,6 +238,10 @@ public:
     // Return whether the view is in a window.
     virtual bool isViewInWindow() = 0;
 
+#if PLATFORM(WPE)
+    virtual bool isViewFrozen() = 0;
+#endif
+
     // Return whether the view is visually idle.
     virtual bool isVisuallyIdle() { return !isViewVisible(); }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2187,6 +2187,8 @@ void WebPageProxy::updateActivityState(OptionSet<ActivityState::Flag> flagsToUpd
         m_activityState.add(ActivityState::IsLoading);
     if (flagsToUpdate & ActivityState::IsCapturingMedia && m_mediaState.containsAny({ MediaProducerMediaState::HasActiveAudioCaptureDevice,  MediaProducerMediaState::HasActiveVideoCaptureDevice }))
         m_activityState.add(ActivityState::IsCapturingMedia);
+    if (flagsToUpdate & ActivityState::IsFrozen && pageClient().isViewFrozen())
+        m_activityState.add(ActivityState::IsFrozen);
 }
 
 void WebPageProxy::activityStateDidChange(OptionSet<ActivityState::Flag> mayHaveChanged, ActivityStateChangeDispatchMode dispatchMode, ActivityStateChangeReplyMode replyMode)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3622,6 +3622,18 @@ void WebPage::visibilityDidChange()
     }
 }
 
+void WebPage::frozenDidChange()
+{
+    if (auto* frame = m_mainFrame->coreFrame()) {
+        const auto isFrozen = m_activityState.contains(ActivityState::IsFrozen);
+
+        if (isFrozen)
+            frame->document()->freeze();
+        else
+            frame->document()->resume();
+    }
+}
+
 void WebPage::setActivityState(OptionSet<ActivityState::Flag> activityState, ActivityStateChangeID activityStateChangeID, CompletionHandler<void()>&& callback)
 {
     LOG_WITH_STREAM(ActivityState, stream << "WebPage " << identifier().toUInt64() << " setActivityState to " << activityState);
@@ -3646,6 +3658,9 @@ void WebPage::setActivityState(OptionSet<ActivityState::Flag> activityState, Act
 
     if (changed & ActivityState::IsVisible)
         visibilityDidChange();
+
+    if (changed & ActivityState::IsFrozen)
+        frozenDidChange();
 }
 
 void WebPage::setLayerHostingMode(LayerHostingMode layerHostingMode)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1678,6 +1678,7 @@ private:
     void setInitialFocus(bool forward, bool isKeyboardEventValid, const WebKeyboardEvent&, CompletionHandler<void()>&&);
     void updateIsInWindow(bool isInitialState = false);
     void visibilityDidChange();
+    void frozenDidChange();
     void setActivityState(OptionSet<WebCore::ActivityState::Flag>, ActivityStateChangeID, CompletionHandler<void()>&&);
     void validateCommand(const String&, CompletionHandler<void(bool, int32_t)>&&);
     void executeEditCommand(const String&, const String&);


### PR DESCRIPTION
- Introduced the `PageLifecycleAPIEnabled` preference toggle in WebPreferences (ON by default).
- Implemented `freeze()` and `resume()` methods in `Document` to dispatch appropriate lifecycle events.
- Added support for `onfreeze` and `onresume` event handlers in the IDL.
- Included `freeze` in `EventNames`.
- Extended `ActivityState` to include `IsFrozen` flag.
- Modified `WebKitWebView` API to use `webkit_web_view_freeze()` instead of `webkit_web_view_suspend()`.

With this change it is possible to call `webkit_web_view_freeze` from the UI process to freeze the web page. The consequence of it is sending the 'freeze' event and partially suspending the page, like suspending all multimedia.

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
