### PR TITLE
ONEM-38747 : Revert "ARRISEOS-46989 - [WPE 2.38] hot plugin case - ma…

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1804,16 +1804,6 @@ PitchCorrectionAlgorithm:
       "PLATFORM(COCOA)": static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestForSpeech)
       default: static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround)
 
-PlatformHDRCapabilities:
-  type: bool
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 PluginsEnabled:
   type: bool
   webcoreGetter: arePluginsEnabled

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -22,6 +22,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <string>
 #include "config.h"
 #include "PlatformScreen.h"
 
@@ -31,7 +32,6 @@
 #include "FrameView.h"
 #include "Logging.h"
 #include "NotImplemented.h"
-#include "Page.h"
 #include "Widget.h"
 
 namespace WebCore {
@@ -97,21 +97,24 @@ bool screenSupportsExtendedColor(Widget*)
 
 bool screenSupportsHighDynamicRange(Widget* widget)
 {
+    std::string hdrCaps("false");
+
     if(!widget)
     {
         return false;
     }
 
-    if(!widget->root())
+    // Get HDR capabilities of TV and STB
+    char *hdrCapsEnvValue = std::getenv("WPE_HDR_CAPABILITIES");
+
+    if(hdrCapsEnvValue)
     {
-        return false;
+        hdrCaps = hdrCapsEnvValue;
     }
 
-    Frame& frame = widget->root()->frame();
-    bool hdrCaps = frame.settings().platformHDRCapabilities();
+    WTFLogAlways("Supports HDR Caps - %s", hdrCaps.c_str());
 
-    WTFLogAlways("Supports HDR Capabilities - %d", hdrCaps);
-    return hdrCaps;
+    return (hdrCaps == "true");
 }
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -188,7 +188,6 @@ enum {
     PROP_ENABLE_SERVICE_WORKER,
     PROP_ENABLE_ICE_CANDIDATE_FILTERING,
     PROP_WEBRTC_UDP_PORTS_RANGE,
-    PROP_PLATFORM_HDR_CAPABILITIES,
     N_PROPERTIES,
 };
 
@@ -449,9 +448,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     case PROP_WEBRTC_UDP_PORTS_RANGE:
         webkit_settings_set_webrtc_udp_ports_range(settings, g_value_get_string(value));
         break;
-    case PROP_PLATFORM_HDR_CAPABILITIES:
-        webkit_settings_set_platform_hdr_capabilities(settings, g_value_get_boolean(value));
-        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -682,9 +678,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
     case PROP_WEBRTC_UDP_PORTS_RANGE:
         g_value_set_string(value, webkit_settings_get_webrtc_udp_ports_range(settings));
-        break;
-    case PROP_PLATFORM_HDR_CAPABILITIES:
-        g_value_set_boolean(value, webkit_settings_get_platform_hdr_capabilities(settings));
         break;
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -1799,22 +1792,6 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         _("WebRTC UDP ports range"),
         _("WebRTC UDP ports range, the format is min-port:max-port"),
         nullptr, // A null string forces the default value.
-        readWriteConstructParamFlags);
-
-    /**
-     * WebKitSettings:platform-hdr-capabilities:
-     *
-     * Allow customization of platform hdr capabilities.
-     *
-     * This settings can be used to determine the HDR capabilities of the platform.
-     *
-     * Since: 2.38
-     */
-    sObjProperties[PROP_PLATFORM_HDR_CAPABILITIES] = g_param_spec_boolean(
-        "platform-hdr-capabilities",
-        _("Platform HDR Capabilities"),
-        _("Platform HDR Capabilities, boolean value"),
-        FALSE,
         readWriteConstructParamFlags);
 
     g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
@@ -4556,42 +4533,4 @@ webkit_settings_set_webrtc_udp_ports_range(WebKitSettings* settings, const gchar
 #else
     UNUSED_PARAM(udpPortsRange);
 #endif
-}
-
-/**
- * webkit_settings_get_platform_hdr_capabilities:
- * @settings: a #WebKitSettings
- *
- * Get the [property@Settings:platform-hdr-capabilities] property.
- *
- * Returns: The Platform HDR Capabilities, or FALSE if un-set.
- *
- * Since: 2.38
- */
-gboolean
-webkit_settings_get_platform_hdr_capabilities(WebKitSettings* settings)
-{
-    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
-    return settings->priv->preferences->platformHDRCapabilities();
-}
-
-/**
- * webkit_settings_set_platform_hdr_capabilities:
- * @settings: a #WebKitSettings
- * @platform_hdr_caps: Value to be set
- *
- * Set the [property@Settings:platform-hdr-capabilities] property.
- *
- * Since: 2.38
- */
-void
-webkit_settings_set_platform_hdr_capabilities(WebKitSettings* settings, gboolean hdrCaps)
-{
-    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
-    WebKitSettingsPrivate* priv = settings->priv;
-    if (priv->preferences->platformHDRCapabilities() == hdrCaps)
-        return;
-
-    priv->preferences->setPlatformHDRCapabilities(hdrCaps);
-    g_object_notify(G_OBJECT(settings), "platform-hdr-capabilities");
 }

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
@@ -547,13 +547,6 @@ WEBKIT_API void
 webkit_settings_set_webrtc_udp_ports_range                     (WebKitSettings *settings,
                                                                 const gchar    *udp_port_range);
 
-WEBKIT_API void
-webkit_settings_set_platform_hdr_capabilities                  (WebKitSettings* settings,
-                                                                const gboolean hdrCaps);
-
-WEBKIT_API gboolean
-webkit_settings_get_platform_hdr_capabilities                  (WebKitSettings* settings);
-
 G_END_DECLS
 
 #endif /* WebKitSettings_h */


### PR DESCRIPTION
…tchMedia("(dynamic-range: high)") always returns matches=false"

This reverts commit 06a1b027f588afe55c380940238ee13388fb33ae.

Changes related to PR: https://github.com/LibertyGlobal/WPEWebKit/pull/470 reverted to merge solution from upstream.

This revert is planned as part of this ticket: https://jira.lgi.io/browse/ONEM-38747
