### PR TITLE
ONEM-38747 : Revert "ARRISEOS-46916: [WPE 2.38] matchMedia("(dynamic-…

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -98,7 +98,7 @@ constexpr DynamicRangeMode preferredDynamicRangeMode(Widget* = nullptr) { return
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
 WEBCORE_EXPORT bool screenSupportsHighDynamicRange(Widget* = nullptr);
 #else
-bool screenSupportsHighDynamicRange(Widget* = nullptr);
+constexpr bool screenSupportsHighDynamicRange(Widget* = nullptr) { return false; }
 #endif
 
 struct ScreenProperties;

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -22,7 +22,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <string>
+
 #include "config.h"
 #include "PlatformScreen.h"
 
@@ -30,7 +30,6 @@
 #include "FloatRect.h"
 #include "Frame.h"
 #include "FrameView.h"
-#include "Logging.h"
 #include "NotImplemented.h"
 #include "Widget.h"
 
@@ -93,28 +92,6 @@ DestinationColorSpace screenColorSpace(Widget*)
 bool screenSupportsExtendedColor(Widget*)
 {
     return false;
-}
-
-bool screenSupportsHighDynamicRange(Widget* widget)
-{
-    std::string hdrCaps("false");
-
-    if(!widget)
-    {
-        return false;
-    }
-
-    // Get HDR capabilities of TV and STB
-    char *hdrCapsEnvValue = std::getenv("WPE_HDR_CAPABILITIES");
-
-    if(hdrCapsEnvValue)
-    {
-        hdrCaps = hdrCapsEnvValue;
-    }
-
-    WTFLogAlways("Supports HDR Caps - %s", hdrCaps.c_str());
-
-    return (hdrCaps == "true");
 }
 
 #if ENABLE(TOUCH_EVENTS)


### PR DESCRIPTION
…range: high)") always returns matches=false"

This reverts commit e6febd2a2a2bf7775f415d3340a692325fb80ef2.

Changes related to PR: https://github.com/LibertyGlobal/WPEWebKit/pull/459 reverted to merge solution from upstream.

This revert is planned as part of this ticket: https://jira.lgi.io/browse/ONEM-38747