### PR TITLE
[ONEM-41930]: Avoid crashing with null answers during session load

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -624,7 +624,7 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
             }
         } else {
             GST_ERROR("session %s not loaded", m_sessionID.utf8().data());
-            if (responseMessage->isEmpty())
+            if (!responseMessage || responseMessage->isEmpty())
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder({ }));
             else {
                 auto responseData = responseMessage->extractData();
@@ -634,8 +634,10 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
             }
         }
     });
-    if (!m_session || m_sessionID.isEmpty() || opencdm_session_load(m_session->get()))
+    if (!m_session || m_sessionID.isEmpty() || opencdm_session_load(m_session->get())) {
+        GST_DEBUG("loading failed");
         sessionFailure();
+    }
 }
 
 void CDMInstanceSessionThunder::closeSession(const String& sessionID, CloseSessionCallback&& callback)


### PR DESCRIPTION
OpenCDM/Thunder can answer with a null message when loading a wrong session. This change is to fix the crash seen during MediaKeySession::load API when session is nullptr.

Changes provided by upstream : https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/78df714bd59669c2261562f3ecf0262fcdfcf02a
