### PR TITLE
[ARRISAPOL-3803][GStreamer] Sometimes progressive playback is not resumed after seek

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2743,6 +2743,13 @@ void MediaPlayerPrivateGStreamer::updateStates()
         GST_DEBUG_OBJECT(pipeline(), "Async: State: %s, pending: %s", gst_element_state_get_name(m_currentState), gst_element_state_get_name(pending));
         // Change in progress.
 
+        if (m_currentState == GST_STATE_PAUSED && m_isBuffering) {
+            // If we are buffering, we could miss HaveCurrentData state if buffering finished before the transition completes.
+            GST_DEBUG_OBJECT(pipeline(), "Async: [Buffering] still buffering, so force HaveCurrentData.");
+            m_readyState = MediaPlayer::ReadyState::HaveCurrentData;
+            m_networkState = MediaPlayer::NetworkState::Loading;
+        }
+
         // Delay the m_isBuffering change by returning it to its previous value. Without this, the false --> true change
         // would go unnoticed by the code that should trigger a pause.
         if (m_wasBuffering != m_isBuffering && !m_isPaused && m_playbackRate) {


### PR DESCRIPTION
[ARRISAPOL-3803][GStreamer] Sometimes progressive playback is not resumed after seek

https://bugs.webkit.org/show_bug.cgi?id=300041

Reviewed by Philippe Normand.

Sometimes, in a downstream multimedia player, regular video playback remains paused after seek instead of resuming automatically. It will play normally when play() or another seek operation are manually triggered.

Log analys shows that in the failing case the browser missed the state transition to 'HaveCurrentData', and application can't resume playback after seek. It was missed because it happened the gstreamer pipeline remains in state transition for too long and can't process buffering events. Normally it goes: seek -> Paused pipeline -> buffering (HaveCurrentData) -> finish_buffering(HaveEnoughData) -> start_playback. However, in the failing case, seek takes too long (~2sec) to set the PAUSED state on the pipeline and we are missing the buffering(HaveCurrentData) stage.

See: https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1561

This patch returns the player readyState to HaveCurrentData and the networkState to Loading when a seek is being processed. The states will reach their final values as soon as the async state transition caused by the seek finishes.

Original author: Volodymyr Ogorodnik (https://github.com/volodymyr-ogorodnik-red)

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::updateStates): Reset readyState and networkState to HaveCurrentData and Loading while the player is in an async state transition (in a seek) and buffering.

Canonical link: https://commits.webkit.org/300933@main
