### PR TITLE
[ARRISEOS-48378] : [Apple TV+] CS2400 After audio changed while playing video

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -897,6 +897,11 @@ void webKitMediaSrcFlush(WebKitMediaSrc* source, const AtomString& streamName, G
     GST_DEBUG_OBJECT(source, "Received non-seek flush request for stream '%s'.", streamName.string().utf8().data());
     Stream* stream = source->priv->streamByName(streamName);
 
+    if (!stream) {
+        GST_INFO_OBJECT(source, "Ignoring flush on track not present in this WebKitMediaSrc");
+        return;
+    }
+
     webKitMediaSrcStreamFlush(stream, false, time);
 }
 


### PR DESCRIPTION
1. Description of the issue
Browser crashes with CS2400 after changing Audio Language while playing a video in AppleTV+.

2. Reproducibility rate
- Seen 6 out of 10

3. Environment details
Environment: LabCI
Device: VIP5002W
Build Version: 5.24
Software Version: VIP5002W-mon-dbg-03.04-000-aa-AL-20250909190002-un000

4. Scenario to reproduce
1. Start AppleTV+ from the App Store
2. Let the video in the EPIC carousel (the one in the top of the home page) to start playing and then press the info icon to see it in full screen
3. Then press the UP key to access player controls and switch the Audio until it crashes
4. Repeat step 2 and 3 again on the next asset from the EPIC carousel until it crashes

See attached video for reference

5. Expected result
Audio changes without browser crash

6. Actual results
Browser crash (CS2400 error) after switching audio