### PR TITLE
ARRISEOS-48622: Don't release CDM when changing keys

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -161,6 +161,10 @@ void MediaKeys::detachCDMClient(CDMClient& client)
 {
     ASSERT(m_cdmClients.contains(client));
     m_cdmClients.remove(client);
+}
+
+void MediaKeys::releaseCDM()
+{
     if (m_cdmClients.computesEmpty()) {
         m_instance->releaseCDM();
     }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -70,6 +70,7 @@ public:
 
     void attachCDMClient(CDMClient&);
     void detachCDMClient(CDMClient&);
+    void releaseCDM();
     void attemptToResumePlaybackOnClients();
 
     bool hasOpenSessions() const;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -608,6 +608,7 @@ HTMLMediaElement::~HTMLMediaElement()
 #if ENABLE(ENCRYPTED_MEDIA)
     if (m_mediaKeys) {
         m_mediaKeys->detachCDMClient(*this);
+        m_mediaKeys->releaseCDM();
         if (m_player)
             m_player->cdmInstanceDetached(m_mediaKeys->cdmInstance());
     }
@@ -2813,6 +2814,7 @@ void HTMLMediaElement::setMediaKeys(MediaKeys* mediaKeys, Ref<DeferredPromise>&&
 {
     // https://w3c.github.io/encrypted-media/#dom-htmlmediaelement-setmediakeys
     // W3C Editor's Draft 23 June 2017
+    INFO_LOG(LOGIDENTIFIER);
 
     // 1. If this object's attaching media keys value is true, return a promise rejected with an InvalidStateError.
     if (m_attachingMediaKeys) {
@@ -6100,6 +6102,7 @@ void HTMLMediaElement::stop()
 
     if (m_mediaKeys) {
         m_mediaKeys->detachCDMClient(*this);
+        m_mediaKeys->releaseCDM();
         if (m_player)
             m_player->cdmInstanceDetached(m_mediaKeys->cdmInstance());
     }


### PR DESCRIPTION
When setMediaKeys is being called with the new key, don't release CDM session as it seems that imediate CDM session creation after CDM destroy causes crash.