### PR TITLE
[ONEM-43489] fix build revision generation

### DIFF
--- a/Tools/glib/apply-build-revision-to-files.py
+++ b/Tools/glib/apply-build-revision-to-files.py
@@ -31,24 +31,19 @@ WEBKIT_TOP_LEVEL = Path(__file__).parent.parent.parent.resolve()
 def get_revision_from_most_recent_git_commit():
     with open(os.devnull, 'w') as devnull:
         try:
-            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "origin/HEAD"), stderr=devnull)
+            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%H", "HEAD"), stderr=devnull)
         except subprocess.CalledProcessError:
             # This may happen with shallow checkouts whose HEAD has been
             # modified; there is no origin reference anymore, and git
             # will fail - let's pretend that this is not a repo at all
             return None
 
-        # Commit messages tend to be huge and the metadata we're looking
-        # for is at the very end. Also a spoofed 'Canonical link' mention
-        # could appear early on. So make sure we get the right metadata by
-        # reversing the contents. And this is a micro-optimization as well.
-        for line in reversed(commit_message.splitlines()):
-            parsed = line.split(b':')
-            key = parsed[0]
-            contents = b':'.join(parsed[1:])
-            if key == b'Canonical link':
-                url = contents.decode('utf-8').strip()
-                revision = urlparse(url).path[1:]  # strip leading /
+        # Just use last commit hash as revision,
+        # add some sanity check we get 40 symbols
+        for line in commit_message.splitlines():
+            if len(line) == 40:
+                rev = line.decode('utf-8')
+                revision = 'git@' + rev[:12]
                 return revision
     return None
 


### PR DESCRIPTION
 - local commits does not have 'Canonical' links in description, 
   so we will use last commit hash instead
