### PR TITLE
[ONEM-41937] Fix sample DTS to prevent deletion of preexisting samples

### DIFF
--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt
@@ -1,0 +1,124 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+Test 1: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+Test 1: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({50/10 = 5.000000}), flags(1), generation(1)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 2: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp, and a last sync sample.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+Test 2: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '6') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({50/10 = 5.000000}), flags(1), generation(1)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 3: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+Test 3: Segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend
+beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a
+sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that.
+Same duration samples.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 4: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp, and a last sync sample.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+Test 4: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend
+beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a
+sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that.
+Same duration samples.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '6') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 5: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp, and a last sync sample.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+Test 5: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend
+beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a
+sample appended in the future (DTS 29/10). This isn't met, so the whole correction algorithm bails out.
+and all the conflicting samples are deleted (old behaviour). Same duration samples.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({19/10 = 1.900000}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-samples-out-of-order-erase-last-previous-frames</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var mediaSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+
+        // Test 1.
+
+        consoleWrite("Test 1: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            // Syntax: makeASample(presentationTime, decodeTime, duration, timeScale, trackID, flags, generation)
+            makeASample( 0,  0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(10, 10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(20, 20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(30, 30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 1: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 9, 50, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 2.
+
+        consoleWrite("Test 2: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp, and a last sync sample.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(  0,   0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample( 10,  10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 20,  20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 30,  30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(100, 100, 10, 10, 0, SAMPLE_FLAG.SYNC, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 2: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 9, 50, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 6);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 3.
+
+        consoleWrite("Test 3: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample( 0,  0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(10, 10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(20, 20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(30, 30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 3: Segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend ");
+        consoleWrite("beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a ");
+        consoleWrite("sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that. ");
+        consoleWrite("Same duration samples.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 29, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 4.
+
+        consoleWrite("Test 4: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp, and a last sync sample.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(  0,   0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample( 10,  10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 20,  20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 30,  30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(100, 100, 10, 10, 0, SAMPLE_FLAG.SYNC, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 4: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend ");
+        consoleWrite("beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a ");
+        consoleWrite("sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that. ");
+        consoleWrite("Same duration samples.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 29, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 6);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 5.
+
+        consoleWrite("Test 5: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp, and a last sync sample.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(  0,   0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample( 10,  10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 20,  20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 30,  30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(100, 100, 10, 10, 0, SAMPLE_FLAG.SYNC, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 5: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend ");
+        consoleWrite("beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a ");
+        consoleWrite("sample appended in the future (DTS 29/10). This isn't met, so the whole correction algorithm bails out. ");
+        consoleWrite("and all the conflicting samples are deleted (old behaviour). Same duration samples.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 19, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -932,6 +932,14 @@ void SourceBufferPrivate::didReceiveSample(Ref<MediaSample>&& originalSample)
                 erasedSamples.addRange(iterPair.first, iterPair.second);
         }
 
+        // There are many files out there where the frame times are not perfectly contiguous and may have small overlaps
+        // between the beginning of a frame and the end of the previous one; therefore a tolerance is needed whenever
+        // durations are considered.
+        // For instance, most WebM files are muxed rounded to the millisecond (the default TimecodeScale of the format)
+        // but their durations use a finer timescale (causing a sub-millisecond overlap). More rarely, there are also
+        // MP4 files with slightly off tfdt boxes, presenting a similar problem at the beginning of each fragment.
+        const MediaTime contiguousFrameTolerance = MediaTime(1, 1000);
+
         // When appending media containing B-frames (media whose samples' presentation timestamps
         // do not increase monotonically, the prior erase steps could leave samples in the trackBuffer
         // which will be disconnected from its previous I-frame. If the incoming frame is an I-frame,
@@ -947,25 +955,42 @@ void SourceBufferPrivate::didReceiveSample(Ref<MediaSample>&& originalSample)
             if (nextSampleInDecodeOrder == trackBuffer.samples().decodeOrder().end())
                 break;
 
-            if (nextSampleInDecodeOrder->second->isSync() && nextSampleInDecodeOrder->second->presentationTime() > sample->presentationTime())
+            auto nextSampleInDecodeOrderRef { nextSampleInDecodeOrder->second };
+            if (nextSampleInDecodeOrderRef->isSync() && nextSampleInDecodeOrderRef->presentationTime() > sample->presentationTime())
                 break;
 
             auto nextSyncSample = trackBuffer.samples().decodeOrder().findSyncSampleAfterDecodeIterator(nextSampleInDecodeOrder);
-            while (nextSyncSample != trackBuffer.samples().decodeOrder().end() && nextSyncSample->second->presentationTime() <= sample->presentationTime())
+            while (nextSyncSample != trackBuffer.samples().decodeOrder().end() && RefPtr { nextSyncSample->second }->presentationTime() <= sample->presentationTime())
                 nextSyncSample = trackBuffer.samples().decodeOrder().findSyncSampleAfterDecodeIterator(nextSyncSample);
 
-            INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", *nextSampleInDecodeOrder->second.get(), " to: ", (nextSyncSample == trackBuffer.samples().decodeOrder().end() ? "[end]"_s : toString(*nextSyncSample->second.get())));
+            // Note that prev(begin()) is Undefined Behaviour, so we exclude that case for nextSyncSample in the if.
+            // We also want to make sure that the list isn't empty in case nextSyncSample is end(), so there's at least
+            // a previous element to get in that case.
+            if (nextSampleInDecodeOrderRef->presentationTime() < sample->presentationTime()
+                && nextSyncSample != trackBuffer.samples().decodeOrder().begin()
+                && trackBuffer.samples().decodeOrder().size() > 0) {
+                // Try to fix the out-of-ordering by placing the decoding timestamp of sample after the decoding timestamp
+                // of the last pre-existing sample before the next sync sample whis has a presentationTime lower than sample.
+                // This would have been the last sample to be erased if this decoding timestamp correction wasn't applied.
+                auto lastSampleBeforeSyncOrBeforeEnd = std::prev(nextSyncSample);
+                // We also exclude the case of no sample previous to the last one.
+                auto lastSampleBeforeSyncOrBeforeEndRef = lastSampleBeforeSyncOrBeforeEnd->second;
+                if (lastSampleBeforeSyncOrBeforeEndRef->presentationTime() < sample->presentationTime()) {
+                    const MediaTime epsilon = MediaTime(100, 1000000); // 100 µs.
+                    auto safeDecodeTime = lastSampleBeforeSyncOrBeforeEndRef->decodeTime() + epsilon;
+                    if (safeDecodeTime > sample->decodeTime()
+                        && safeDecodeTime < (sample->decodeTime() + sample->duration() - 2 * contiguousFrameTolerance)) {
+                        INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", *nextSampleInDecodeOrderRef.get(), " to: ", (nextSyncSample == trackBuffer.samples().decodeOrder().end() ? "[end]"_s : toString(*nextSyncSample->second.get())),
+                        ", but fixed the ordering by changing sample DTS from ", sample->decodeTime(), " to ", safeDecodeTime);
+                        sample->setTimestamps(sample->presentationTime(), safeDecodeTime);
+                        break;
+                    }
+                }
+            }
+
+            INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", *nextSampleInDecodeOrderRef.get(), " to: ", (nextSyncSample == trackBuffer.samples().decodeOrder().end() ? "[end]"_s : toString(*nextSyncSample->second.get())));
             erasedSamples.addRange(nextSampleInDecodeOrder, nextSyncSample);
         } while (false);
-
-        // There are many files out there where the frame times are not perfectly contiguous and may have small overlaps
-        // between the beginning of a frame and the end of the previous one; therefore a tolerance is needed whenever
-        // durations are considered.
-        // For instance, most WebM files are muxed rounded to the millisecond (the default TimecodeScale of the format)
-        // but their durations use a finer timescale (causing a sub-millisecond overlap). More rarely, there are also
-        // MP4 files with slightly off tfdt boxes, presenting a similar problem at the beginning of each fragment.
-        // Same as tolerance in SourceBuffer::canPlayThroughRange().
-        const MediaTime contiguousFrameTolerance = MediaTime(1, 1000);
 
         // If highest presentation timestamp for track buffer is set and less than or equal to presentation timestamp
         if (trackBuffer.highestPresentationTimestamp().isValid() && trackBuffer.highestPresentationTimestamp() - contiguousFrameTolerance <= presentationTimestamp) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -468,20 +468,15 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
     GstSegment* segment = gst_sample_get_segment(sample.get());
     auto mediaSample = MediaSampleGStreamer::create(WTFMove(sample), track.presentationSize, track.trackId);
 
-    /* this logic does not work when we insert piece of stream with different segment start
-       and then return back to original offset. It causes the inserted segment is shifted/overlapped.
-
     if (segment && (segment->time || segment->start)) {
         // MP4 has the concept of edit lists, where some buffer time needs to be offsetted, often very slightly,
         // to get exact timestamps.
-
         MediaTime pts = bufferTimeToStreamTime(segment, GST_BUFFER_PTS(buffer));
         MediaTime dts = bufferTimeToStreamTime(segment, GST_BUFFER_DTS(buffer));
         GST_TRACE_OBJECT(track.appsinkPad.get(), "Mapped buffer to segment, PTS %" GST_TIME_FORMAT " -> %s DTS %" GST_TIME_FORMAT " -> %s",
             GST_TIME_ARGS(GST_BUFFER_PTS(buffer)), pts.toString().utf8().data(), GST_TIME_ARGS(GST_BUFFER_DTS(buffer)), dts.toString().utf8().data());
         mediaSample->setTimestamps(pts, dts);
-        
-    } else */ if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000) {
+    } else if (!GST_BUFFER_DTS(buffer) && GST_BUFFER_PTS(buffer) > 0 && GST_BUFFER_PTS(buffer) <= 100'000'000) {
         // Because a track presentation time starting at some close to zero, but not exactly zero time can cause unexpected
         // results for applications, we extend the duration of this first sample to the left so that it starts at zero.
         // This is relevant for files that should have an edit list but don't, or when using GStreamer < 1.16, where


### PR DESCRIPTION
 - see original description from https://github.com/WebKit/WebKit/pull/57363 below
 - this also reverts commit 90c814dcca2255f0f1c4f4a23d27ec5c203ecf04 (disable MP4 edit-lists support

[EXPERIMENTAL][MSE] Fix sample DTS to prevent deletion of preexisting samples when PTS doesn't conflict

Let's consider a preexisting samples A, B, C, and a new sample N with the following timestamps:

          Decoding time  Presentation time
          -------------  -----------------
Sample A: 827.826164000  827.826164000
Sample B: 827.826164100  827.826164100
Sample C: 827.826164200  827.826164200
Sample N: 827.826125000  827.909542000

These disparities in DTS vs. PTS offsets between samples A and B exist because both samples come from completely different videos (eg: because of ad insertion).

In a timeline:

DTS ···NABC·······
PTS ····ABC···N···

Judging by PTS, the samples A, B, C should remain and theoretically don't need to be erased. However, considering DTS, the samples A, B, C have to be erased, because the sample N would reach the video decoder earlier (by decoding ordering) and change the state of the decoder, making it unsuitable for samples A, B, C.

This commit tries to fix the situation by changing sample N (the new sample) DTS to a value slightly higher than sample C DTS, like this:

           Decoding time  Presentation time
           -------------  -----------------
Sample A:  827.826164000  827.826164000
Sample B:  827.826164100  827.826164100
Sample C:  827.826164200  827.826164200
Sample N: *827.826164201* 827.909542000

DTS ····ABCN······
PTS ····ABC···N···

This fix avoids the deletion of samples A, B, C and the potential problems associated with that.

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
