### PR TITLE
[ARRISAPOL-3808]Fix for resolving styles with huge number of custom prorperties causi…

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2510,6 +2510,7 @@ rendering/style/StyleBoxData.cpp
 rendering/style/StyleCachedImage.cpp
 rendering/style/StyleContentAlignmentData.cpp
 rendering/style/StyleCursorImage.cpp
+rendering/style/StyleCustomPropertyData.cpp
 rendering/style/StyleDeprecatedFlexibleBoxData.cpp
 rendering/style/StyleFilterData.cpp
 rendering/style/StyleFlexibleBoxData.cpp

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -4374,15 +4374,15 @@ String CSSComputedStyleDeclaration::item(unsigned i) const
         return String();
 
     const auto& inheritedCustomProperties = style->inheritedCustomProperties();
+    // FIXME: findKeyAtIndex does a linear search for the property name, so if
+    // we are called in a loop over all item indexes, we'll spend quadratic time
+    // searching for keys.
 
-    if (i < exposedComputedCSSPropertyIDs().size() + inheritedCustomProperties.size()) {
-        auto results = copyToVector(inheritedCustomProperties.keys());
-        return results.at(i - exposedComputedCSSPropertyIDs().size());
-    }
-
+    if (i < exposedComputedCSSPropertyIDs().size() + inheritedCustomProperties.size())
+        return inheritedCustomProperties.findKeyAtIndex(i - exposedComputedCSSPropertyIDs().size());    
+    
     const auto& nonInheritedCustomProperties = style->nonInheritedCustomProperties();
-    auto results = copyToVector(nonInheritedCustomProperties.keys());
-    return results.at(i - inheritedCustomProperties.size() - exposedComputedCSSPropertyIDs().size());
+    return nonInheritedCustomProperties.findKeyAtIndex(i - inheritedCustomProperties.size() - exposedComputedCSSPropertyIDs().size());
 }
 
 bool ComputedStyleExtractor::propertyMatches(CSSPropertyID propertyID, const CSSValue* value)

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -42,6 +42,11 @@ Ref<CSSCustomPropertyValue> CSSCustomPropertyValue::createWithID(const AtomStrin
     return adoptRef(*new CSSCustomPropertyValue(name, { id }));
 }
 
+bool CSSCustomPropertyValue::isAnimatable() const
+{
+    return std::holds_alternative<Length>(m_value) || std::holds_alternative<Ref<StyleImage>>(m_value);
+}
+
 bool CSSCustomPropertyValue::equals(const CSSCustomPropertyValue& other) const
 {
     if (m_name != other.m_name || m_value.index() != other.m_value.index())

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -87,6 +87,7 @@ public:
 
     Vector<CSSParserToken> tokens() const;
     bool equals(const CSSCustomPropertyValue&) const;
+    bool isAnimatable() const;
 
 private:
     CSSCustomPropertyValue(const AtomString& name, VariantValue&& value)

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -124,8 +124,10 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     }
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
-        for (const auto& it : *map)
+        map->forEach([&](auto& it) {
             values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.get(), m_element->document(), m_element.ptr())));
+            return IterationStatus::Continue;
+        });
     }
 
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2631,18 +2631,18 @@ void RenderStyle::deduplicateInheritedCustomProperties(const RenderStyle& other)
 
 void RenderStyle::setInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
 {
-    auto* existingValue = m_rareInheritedData->customProperties->values.get(name);
+    auto* existingValue = m_rareInheritedData->customProperties->get(name);
     if (existingValue && existingValue->equals(value.get()))
         return;
-    m_rareInheritedData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
+    m_rareInheritedData.access().customProperties.access().set(name, WTFMove(value));
 }
 
 void RenderStyle::setNonInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
 {
-    auto* existingValue = m_rareNonInheritedData->customProperties->values.get(name);
+    auto* existingValue = m_rareNonInheritedData->customProperties->get(name);
     if (existingValue && existingValue->equals(value.get()))
         return;
-    m_rareNonInheritedData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
+    m_rareNonInheritedData.access().customProperties.access().set(name, WTFMove(value));
 }
 
 const LengthBox& RenderStyle::scrollMargin() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -191,8 +191,8 @@ public:
     const PseudoStyleCache* cachedPseudoStyles() const { return m_cachedPseudoStyles.get(); }
 
     void deduplicateInheritedCustomProperties(const RenderStyle&);
-    const CustomPropertyValueMap& inheritedCustomProperties() const { return m_rareInheritedData->customProperties->values; }
-    const CustomPropertyValueMap& nonInheritedCustomProperties() const { return m_rareNonInheritedData->customProperties->values; }
+    const StyleCustomPropertyData& inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
+    const StyleCustomPropertyData& nonInheritedCustomProperties() const { return m_rareNonInheritedData->customProperties.get(); }
     const CSSCustomPropertyValue* getCustomProperty(const AtomString&) const;
     void setInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
     void setNonInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleCustomPropertyData.h"
+
+namespace WebCore {
+
+static constexpr auto maximumAncestorCount = 4;
+
+StyleCustomPropertyData::StyleCustomPropertyData(const StyleCustomPropertyData& other)
+    : m_size(other.m_size)
+    , m_mayHaveAnimatableProperties(other.m_mayHaveAnimatableProperties)
+{
+    auto shouldReferenceAsParentValues = [&] {
+        // Always reference the root style since it likely gets shared a lot.
+        if (!other.m_parentValues && !other.m_ownValues.isEmpty())
+            return true;
+
+        // Limit the list length.
+        if (other.m_ancestorCount >= maximumAncestorCount)
+            return false;
+
+        // If the number of properties is small we just copy them to avoid creating unnecessarily long linked lists.
+        static constexpr auto parentReferencePropertyCountThreshold = 8;
+        return other.m_ownValues.size() > parentReferencePropertyCountThreshold;
+    }();
+
+    // If there are mutations on multiple levels this constructs a linked list of property data objects.
+    if (shouldReferenceAsParentValues)
+        m_parentValues = &other;
+    else {
+        m_parentValues = other.m_parentValues;
+        m_ownValues = other.m_ownValues;
+    }
+
+    if (m_parentValues)
+        m_ancestorCount = m_parentValues->m_ancestorCount + 1;
+
+#if ASSERT_ENABLED
+    if (m_parentValues)
+        m_parentValues->m_hasChildren = true;
+#endif
+}
+
+CSSCustomPropertyValue* StyleCustomPropertyData::get(const AtomString& name) const
+{
+    for (auto* propertyData = this; propertyData; propertyData = propertyData->m_parentValues.get()) {
+        if (auto* value = propertyData->m_ownValues.get(name))
+            return value;
+    }
+    return nullptr;
+}
+
+void StyleCustomPropertyData::set(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
+{
+    ASSERT(!m_hasChildren);
+    ASSERT([&] {
+        auto* existing = get(name);
+        return !existing || !existing->equals(value);
+    }());
+
+    m_mayHaveAnimatableProperties = m_mayHaveAnimatableProperties || value->isAnimatable();
+
+    auto addResult = m_ownValues.set(name, WTFMove(value));
+
+    bool isNewProperty = addResult.isNewEntry && (!m_parentValues || !m_parentValues->get(name));
+    if (isNewProperty)
+        ++m_size;
+}
+
+bool StyleCustomPropertyData::operator==(const StyleCustomPropertyData& other) const
+{
+    if (m_size != other.m_size)
+        return false;
+
+    if (m_parentValues == other.m_parentValues) {
+        // This relies on the values in m_ownValues never being equal to those in m_parentValues.
+        if (m_ownValues.size() != other.m_ownValues.size())
+            return false;
+
+        for (auto& entry : m_ownValues) {
+            auto* otherValue = other.m_ownValues.get(entry.key);
+            if (!otherValue || !entry.value->equals(*otherValue))
+                return false;
+        }
+        return true;
+    }
+
+    bool isEqual = true;
+    forEachInternal([&](auto& entry) {
+        auto* otherValue = other.get(entry.key);
+        if (!otherValue || !entry.value->equals(*otherValue)) {
+            isEqual = false;
+            return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    });
+
+    return isEqual;
+}
+
+template<typename Callback>
+void StyleCustomPropertyData::forEachInternal(Callback&& callback) const
+{
+    Vector<const StyleCustomPropertyData*, maximumAncestorCount> descendants;
+
+    auto isOverridenByDescendants = [&](auto& key) {
+        for (auto* descendant : descendants) {
+            if (descendant->m_ownValues.contains(key))
+                return true;
+        }
+        return false;
+    };
+
+    auto* propertyData = this;
+    while (true) {
+        for (auto& entry : propertyData->m_ownValues) {
+            if (isOverridenByDescendants(entry.key))
+                continue;
+            auto status = callback(entry);
+            if (status == IterationStatus::Done)
+                return;
+        }
+        if (!propertyData->m_parentValues)
+            return;
+        descendants.append(propertyData);
+        propertyData = propertyData->m_parentValues.get();
+    }
+}
+
+void StyleCustomPropertyData::forEach(const Function<IterationStatus(const KeyValuePair<AtomString, RefPtr<CSSCustomPropertyValue>>&)>& callback) const
+{
+    forEachInternal(callback);
+}
+
+AtomString StyleCustomPropertyData::findKeyAtIndex(unsigned index) const
+{
+    unsigned currentIndex = 0;
+    AtomString key;
+    forEachInternal([&](auto& entry) {
+        if (currentIndex == index) {
+            key = entry.key;
+            return IterationStatus::Done;
+        }
+        ++currentIndex;
+        return IterationStatus::Continue;
+    });
+    return key;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.h
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.h
@@ -23,7 +23,9 @@
 
 #include "CSSCustomPropertyValue.h"
 #include <wtf/Forward.h>
+#include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/IterationStatus.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/AtomStringHash.h>
@@ -31,39 +33,38 @@
 namespace WebCore {
 
 class StyleCustomPropertyData : public RefCounted<StyleCustomPropertyData> {
+private:
+    using CustomPropertyValueMap = HashMap<AtomString, RefPtr<CSSCustomPropertyValue>>;
 public:
     static Ref<StyleCustomPropertyData> create() { return adoptRef(*new StyleCustomPropertyData); }
     Ref<StyleCustomPropertyData> copy() const { return adoptRef(*new StyleCustomPropertyData(*this)); }
     
-    bool operator==(const StyleCustomPropertyData& other) const
-    {
-        if (values.size() != other.values.size())
-            return false;
-
-        for (auto& entry : values) {
-            auto otherEntry = other.values.find(entry.key);
-            if (otherEntry == other.values.end() || !entry.value->equals(*otherEntry->value))
-                return false;
-        }
-
-        return true;
-    }
-
+    bool operator==(const StyleCustomPropertyData& other) const;
     bool operator!=(const StyleCustomPropertyData& other) const { return !(*this == other); }
-    
-    void setCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
-    {
-        values.set(name, WTFMove(value));
-    }
 
-    CustomPropertyValueMap values;
+    CSSCustomPropertyValue* get(const AtomString&) const;
+    void set(const AtomString&, Ref<CSSCustomPropertyValue>&&);
+    
+    unsigned size() const { return m_size; }
+    bool mayHaveAnimatableProperties() const { return m_mayHaveAnimatableProperties; }
+    
+    void forEach(const Function<IterationStatus(const KeyValuePair<AtomString, RefPtr<CSSCustomPropertyValue>>&)>&) const;
+    AtomString findKeyAtIndex(unsigned) const;
 
 private:
     StyleCustomPropertyData() = default;
-    StyleCustomPropertyData(const StyleCustomPropertyData& other)
-        : RefCounted<StyleCustomPropertyData>()
-        , values(other.values)
-    { }
+    StyleCustomPropertyData(const StyleCustomPropertyData&);
+
+    template<typename Callback> void forEachInternal(Callback&&) const;
+
+    RefPtr<const StyleCustomPropertyData> m_parentValues;
+    CustomPropertyValueMap m_ownValues;
+    unsigned m_size { 0 };
+    unsigned m_ancestorCount { 0 };
+    bool m_mayHaveAnimatableProperties { false };
+#if ASSERT_ENABLED
+    mutable bool m_hasChildren { false };
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
After logged into the Mycanal+ app, there is a navigation delay of  >4sec is seen when navigating between the tiles which blocks the key presses until the delay completes and navigation not smooth.
The reproduction rate is 6-7 times out of 13 attempts.
Found the root cause by upstream that the delay is due to Style recalculations. It seen that a big number of custom properties of css styles used in root element of mycanal+ app page. Navigation delay caused by CSS style recalculation due to large number of custom properties defined on root element, which triggered heavy style resolution and layout work on focus change between tiles.

**The below is the upstream issue:**
https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1599

They found the optimizations that improves performance and memory usage in case of pages with big number of custom properties of css styles used in root element, like it is in case of MyCanalPlus app from **wpe-2.46** and backported them to **wpe-2.38** and merged the changes as below,
https://github.com/pgorszkowski-igalia/WPEWebKit/commit/ffa4c4b5d5cedd73c7a4373809a34062a0ca7b08

We see the  fix solve the unusual freezes and no regression seen with the fix changes.