### PR TITLE
ONEM-42756: Added support for persistent license load session

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -123,6 +123,14 @@ const String& MediaKeySession::sessionId() const
     return m_sessionId;
 }
 
+bool MediaKeySession::hasSecurityOrigin(const String& origin) const
+{
+    String sessionOrigin;
+    if (auto* document = downcast<Document>(scriptExecutionContext()))
+        sessionOrigin = document->securityOrigin().toString();
+    return origin == sessionOrigin;
+}
+
 double MediaKeySession::expiration() const
 {
     return m_expiration;
@@ -313,19 +321,22 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
             return;
         }
 
-        // 8.3. If there is a MediaKeySession object that is not closed in this object's Document whose sessionId attribute is sanitized session ID, reject promise with a QuotaExceededError.
-        // FIXME: This needs a global MediaKeySession tracker.
-
         String origin;
         if (auto* document = downcast<Document>(scriptExecutionContext()))
             origin = document->securityOrigin().toString();
+        // 8.3. If there is a MediaKeySession object that is not closed in this object's Document whose sessionId attribute is sanitized session ID, reject promise with a QuotaExceededError.
+        if (m_keys && m_keys->hasOpenSessionWithIdForOrigin(sanitizedSessionId.value(), origin)) {
+            ERROR_LOG(identifier, "Rejected: Another open MediaKeySession with the same session ID already exists for this security origin");
+            promise->reject(QuotaExceededError);
+            return;
+        }
 
         // 8.4. Let expiration time be NaN.
         // 8.5. Let message be null.
         // 8.6. Let message type be null.
         // 8.7. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 8.8. Use the cdm to execute the following steps:
-        m_instanceSession->loadSession(m_sessionType, *sanitizedSessionId, origin, [this, weakThis, promise = WTFMove(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTFMove(identifier)] (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+	m_instanceSession->loadSession(m_sessionType, *sanitizedSessionId, origin, [this, weakThis, promise = WTFMove(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTFMove(identifier), origin] (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
             // 8.8.1. If there is no data stored for the sanitized session ID in the origin, resolve promise with false and abort these steps.
             // 8.8.2. If the stored session's session type is not the same as the current MediaKeySession session type, reject promise with a newly created TypeError.
             // 8.8.3. Let session data be the data stored for the sanitized session ID in the origin. This must not include data from other origin(s) or that is not associated with an origin.
@@ -359,7 +370,17 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
             }
 
             // 8.9. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, knownKeys = WTFMove(knownKeys), expiration = WTFMove(expiration), message = WTFMove(message), sanitizedSessionId, succeeded, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+	    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, knownKeys = WTFMove(knownKeys), expiration = WTFMove(expiration), message = WTFMove(message), sanitizedSessionId, origin = WTFMove(origin), succeeded, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+                // We must reevaluate condition 8.3 to avoid a race condition in case the id of the sessions
+                // compared before were empty at the moment of comparison because they were in the middle of a
+                // session loading that completed asynchronously. Their ids should have settled now, so let's
+                // check again.
+                if (m_keys && m_keys->hasOpenSessionWithIdForOrigin(sanitizedSessionId, origin)) {
+                    ERROR_LOG(identifier, "Rejected (later): Another open MediaKeySession with the same session ID already exists for this security origin");
+                    promise->reject(QuotaExceededError);
+                    return;
+                }
+
                 // 8.9.1. If any of the preceding steps failed, reject promise with a the appropriate error name.
                 if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
                     ERROR_LOG(identifier, "::task() Rejected: Other failure");

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -91,6 +91,8 @@ public:
 
     unsigned internalInstanceSessionObjectRefCount() const { return m_instanceSession->refCount(); }
 
+    bool hasSecurityOrigin(const String&) const;
+
 private:
     MediaKeySession(Document&, WeakPtr<MediaKeys>&&, MediaKeySessionType, bool useDistinctiveIdentifier, Ref<CDM>&&, Ref<CDMInstanceSession>&&);
     void enqueueMessage(MediaKeyMessageType, const SharedBuffer&);

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -180,6 +180,15 @@ bool MediaKeys::hasOpenSessions() const
         });
 }
 
+bool MediaKeys::hasOpenSessionWithIdForOrigin(const String& sessionId, const String& origin) const
+{
+    return std::any_of(m_sessions.begin(), m_sessions.end(),
+        [sessionId, origin](auto& session) {
+            return session->sessionId() == sessionId && !session->isClosed()
+                && session->hasSecurityOrigin(origin);
+        });
+}
+
 void MediaKeys::unrequestedInitializationDataReceived(const String& initDataType, Ref<SharedBuffer>&& initData)
 {
     for (auto& cdmClient : m_cdmClients)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -73,6 +73,7 @@ public:
     void attemptToResumePlaybackOnClients();
 
     bool hasOpenSessions() const;
+    bool hasOpenSessionWithIdForOrigin(const String& sessionId, const String& origin) const;
     CDMInstance& cdmInstance() { return m_instance; }
     const CDMInstance& cdmInstance() const { return m_instance; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -284,7 +284,8 @@ CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instanc
     m_thunderSessionCallbacks.process_challenge_callback = [](OpenCDMSession*, void* userData, const char[], const uint8_t challenge[],
         const uint16_t challengeLength) {
         GST_DEBUG("Got 'challenge' OCDM notification with length %hu", challengeLength);
-        ASSERT(challengeLength > 0);
+
+	// Persistent license loading can generate a challenge with length 0.
         callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(challenge,
             challengeLength)]() mutable {
             if (!session)
@@ -370,6 +371,11 @@ private:
 
 void CDMInstanceSessionThunder::challengeGeneratedCallback(RefPtr<SharedBuffer>&& buffer)
 {
+    if (!buffer->size()) {
+        GST_DEBUG("empty response");
+        return;
+    }
+
     ParsedResponseMessage parsedResponseMessage(buffer);
     if (!parsedResponseMessage) {
         GST_ERROR("response message parsing failed");
@@ -604,9 +610,58 @@ void CDMInstanceSessionThunder::updateLicense(const String& sessionID, LicenseTy
         sessionChanged(SessionChangedResult::Failure);
 }
 
-void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID, const String&, LoadSessionCallback&& callback)
+void CDMInstanceSessionThunder::loadSession(LicenseType licenseType, const String& sessionID, const String& /* origin */, LoadSessionCallback&& callback)
 {
-    ASSERT_UNUSED(sessionID, sessionID == m_sessionID);
+    ASSERT(isMainThread());
+
+    // MediaKeySession::load() is guaranteeing this (so we don't have to double-check):
+    // - MediaKeySession is not uninitialized (is initialized) and is not closed.
+    // - sessionID is sanitized.
+    // - LicenseType sessionType is not temporary (it's either PersistentUsageRecord or PersistentLicense).
+    // TODO: MediaKeySession::load() isn't checking if there are other open session with the same sessionId
+    //       because it lacks a global MediaKeySession tracker.
+
+    auto instance = cdmInstanceThunder();
+    ASSERT(instance);
+
+    GST_TRACE("Going to load session for session id %s", sessionID.utf8().data());
+
+    OpenCDMSession* session = nullptr;
+    OpenCDMError result = opencdm_construct_session(&instance->thunderSystem(), thunderLicenseType(licenseType), "",
+        nullptr, 0, sessionID.utf8().dataAsUInt8Ptr(), sessionID.length(), &m_thunderSessionCallbacks, this, &session);
+
+    if (!session) {
+        SessionLoadFailure failureReason { SessionLoadFailure::Other };
+        switch (result) {
+            case ERROR_NONE:
+                failureReason = SessionLoadFailure::None;
+                break;
+            case ERROR_KEYSYSTEM_NOT_SUPPORTED:
+            case ERROR_OUT_OF_MEMORY:
+            case ERROR_BUSY_CANNOT_INITIALIZE:
+            case ERROR_BUFFER_TOO_SMALL:
+                failureReason = SessionLoadFailure::QuotaExceeded;
+                break;
+            case ERROR_INVALID_SESSION:
+                failureReason = SessionLoadFailure::NoSessionData;
+            default:
+                break;
+        }
+
+        GST_ERROR("Could not create session. OpenCDMError: %" PRIu32, static_cast<uint32_t>(result));
+
+        callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, failureReason);
+        return;
+    }
+
+    m_session = adoptInBoxPtr(session);
+    m_sessionID = String::fromUTF8(opencdm_session_id(m_session->get()));
+
+    GST_TRACE("Session created with id %s", m_sessionID.utf8().data());
+
+    ASSERT(sessionId == m_sessionID);
+
+    // FIXME: Is this callback for the response actually needed, since we're not doing generateRequest()?
 
     m_sessionChangedCallbacks.append([this, callback = WTFMove(callback)](bool success, RefPtr<SharedBuffer>&& responseMessage) mutable {
         ASSERT(isMainThread());
@@ -614,7 +669,7 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
             if (!responseMessage)
                 callback(m_keyStore.convertToJSKeyStatusVector(), std::nullopt, std::nullopt, SuccessValue::Succeeded, SessionLoadFailure::None);
             else {
-                // FIXME: Using JSON reponse messages is much cleaner than using string prefixes, I believe there
+                // FIXME: Using JSON response messages is much cleaner than using string prefixes, I believe there
                 // will even be other parts of the spec where not having structured data will be bad.
                 ParsedResponseMessage parsedResponseMessage(responseMessage);
                 ASSERT(parsedResponseMessage);
@@ -644,10 +699,15 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
             }
         }
     });
-    if (!m_session || m_sessionID.isEmpty() || opencdm_session_load(m_session->get())) {
-        GST_DEBUG("loading failed");
+
+    result = OpenCDMError::ERROR_NONE;
+    if (!m_session || m_sessionID.isEmpty() || (result = opencdm_session_load(m_session->get()))) {
+        GST_DEBUG("loading failed. OpenCDMError: %" PRIu32, static_cast<uint32_t>(result));
         sessionChanged(SessionChangedResult::Failure);
+        return;
     }
+
+    GST_TRACE("session %s loaded. OpenCDMError: %" PRIu32, m_sessionID.utf8().data(), static_cast<uint32_t>(result));
 }
 
 void CDMInstanceSessionThunder::closeSession(const String& sessionID, CloseSessionCallback&& callback)


### PR DESCRIPTION
Backporting session load API upstream changes -https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/2a862659beaa1546eee47da38d3d162da204ba69 to LGI 26Q1 branch.
